### PR TITLE
[SC-535] add hash & remainingAmount into interaction

### DIFF
--- a/contracts/helpers/WethUnwrapper.sol
+++ b/contracts/helpers/WethUnwrapper.sol
@@ -11,11 +11,13 @@ contract WethUnwrapper is PostInteractionNotificationReceiver {
     receive() external payable {}
 
     function fillOrderPostInteraction(
+        bytes32 /* orderHash */,
         address /* taker */,
         address /* makerAsset */,
         address takerAsset,
         uint256 /* makingAmount */,
         uint256 takingAmount,
+        uint256 /* remainingMakerAmount */,
         bytes calldata interactiveData
     ) external override {
         address payable makerAddress;

--- a/contracts/helpers/WhitelistChecker.sol
+++ b/contracts/helpers/WhitelistChecker.sol
@@ -19,11 +19,13 @@ contract WhitelistChecker is PreInteractionNotificationReceiver {
     }
 
     function fillOrderPreInteraction(
+        bytes32 orderHash,
         address taker,
         address makerAsset,
         address takerAsset,
         uint256 makingAmount,
         uint256 takingAmount,
+        uint256 remainingMakerAmount,
         bytes calldata nextInteractiveData
     ) external override {
         if (whitelistRegistry.status(taker) != 1) revert TakerIsNotWhitelisted();
@@ -32,7 +34,7 @@ contract WhitelistChecker is PreInteractionNotificationReceiver {
             (address interactionTarget, bytes calldata interactionData) = nextInteractiveData.decodeTargetAndCalldata();
 
             PreInteractionNotificationReceiver(interactionTarget).fillOrderPreInteraction(
-                taker, makerAsset, takerAsset, makingAmount, takingAmount, interactionData
+                orderHash, taker, makerAsset, takerAsset, makingAmount, takingAmount, remainingMakerAmount, interactionData
             );
         }
     }

--- a/contracts/interfaces/NotificationReceiver.sol
+++ b/contracts/interfaces/NotificationReceiver.sol
@@ -32,11 +32,13 @@ interface PostInteractionNotificationReceiver {
 
 interface InteractionNotificationReceiver {
     function fillOrderInteraction(
+        bytes32 orderHash,
         address taker,
         address makerAsset,
         address takerAsset,
         uint256 makingAmount,
         uint256 takingAmount,
+        uint256 remainingAmount,
         bytes memory interactiveData
     ) external returns(uint256 offeredTakingAmount);
 }

--- a/contracts/interfaces/NotificationReceiver.sol
+++ b/contracts/interfaces/NotificationReceiver.sol
@@ -8,11 +8,13 @@ pragma abicoder v1;
 /// @title Interface for interactor which acts between `maker => taker` and `taker => maker` transfers.
 interface PreInteractionNotificationReceiver {
     function fillOrderPreInteraction(
+        bytes32 orderHash,
         address taker,
         address makerAsset,
         address takerAsset,
         uint256 makingAmount,
         uint256 takingAmount,
+        uint256 remainingAmount,
         bytes memory interactiveData
     ) external;
 }
@@ -21,17 +23,6 @@ interface PostInteractionNotificationReceiver {
     /// @notice Callback method that gets called after taker transferred funds to maker but before
     /// the opposite transfer happened
     function fillOrderPostInteraction(
-        address taker,
-        address makerAsset,
-        address takerAsset,
-        uint256 makingAmount,
-        uint256 takingAmount,
-        bytes memory interactiveData
-    ) external;
-}
-
-interface InteractionNotificationReceiver {
-    function fillOrderInteraction(
         bytes32 orderHash,
         address taker,
         address makerAsset,
@@ -39,6 +30,17 @@ interface InteractionNotificationReceiver {
         uint256 makingAmount,
         uint256 takingAmount,
         uint256 remainingAmount,
+        bytes memory interactiveData
+    ) external;
+}
+
+interface InteractionNotificationReceiver {
+    function fillOrderInteraction(
+        address taker,
+        address makerAsset,
+        address takerAsset,
+        uint256 makingAmount,
+        uint256 takingAmount,
         bytes memory interactiveData
     ) external returns(uint256 offeredTakingAmount);
 }

--- a/contracts/mocks/HashChecker.sol
+++ b/contracts/mocks/HashChecker.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.15;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../interfaces/NotificationReceiver.sol";
+import "../libraries/ArgumentsDecoder.sol";
+import "../OrderLib.sol";
+
+
+contract HashChecker is PreInteractionNotificationReceiver, Ownable {
+    using OrderLib for OrderLib.Order;
+    using ArgumentsDecoder for bytes;
+
+    error IncorrectOrderHash();
+
+    bytes32 public immutable limitOrderProtocolDomainSeparator;
+    mapping(bytes32 => bool) public hashes;
+
+    constructor (address limitOrderProtocol) {
+        // solhint-disable-next-line avoid-low-level-calls
+        (, bytes memory data) = limitOrderProtocol.call(abi.encodeWithSignature("DOMAIN_SEPARATOR()"));
+        limitOrderProtocolDomainSeparator = abi.decode(data, (bytes32));
+    }
+
+    function setHashOrderStatus(OrderLib.Order calldata order, bool status) external onlyOwner {
+        bytes32 orderHash = order.hash(limitOrderProtocolDomainSeparator);
+        hashes[orderHash] = status;
+    }
+
+    function fillOrderPreInteraction(
+        bytes32 orderHash,
+        address taker,
+        address makerAsset,
+        address takerAsset,
+        uint256 makingAmount,
+        uint256 takingAmount,
+        uint256 remainingMakerAmount,
+        bytes calldata nextInteractiveData
+    ) external override {
+        if (hashes[orderHash] == false) revert IncorrectOrderHash();
+
+        if (nextInteractiveData.length != 0) {
+            (address interactionTarget, bytes calldata interactionData) = nextInteractiveData.decodeTargetAndCalldata();
+
+            PreInteractionNotificationReceiver(interactionTarget).fillOrderPreInteraction(
+                orderHash, taker, makerAsset, takerAsset, makingAmount, takingAmount, remainingMakerAmount, interactionData
+            );
+        }
+    }
+}

--- a/contracts/mocks/RecursiveMatcher.sol
+++ b/contracts/mocks/RecursiveMatcher.sol
@@ -32,13 +32,11 @@ contract RecursiveMatcher is InteractionNotificationReceiver {
     }
 
     function fillOrderInteraction(
-        bytes32 /* hash */,
         address /* taker */,
         address /* makerAsset */ ,
         address /* takerAsset */,
         uint256 /* makingAmount */,
         uint256 /* takingAmount */,
-        uint256 /* remainingMakerAmount */ ,
         bytes calldata interactiveData
     ) external returns(uint256) {
         if(interactiveData[0] == _FINALIZE_INTERACTION) {

--- a/contracts/mocks/RecursiveMatcher.sol
+++ b/contracts/mocks/RecursiveMatcher.sol
@@ -32,11 +32,13 @@ contract RecursiveMatcher is InteractionNotificationReceiver {
     }
 
     function fillOrderInteraction(
+        bytes32 /* hash */,
         address /* taker */,
         address /* makerAsset */ ,
         address /* takerAsset */,
         uint256 /* makingAmount */,
         uint256 /* takingAmount */,
+        uint256 /* remainingMakerAmount */ ,
         bytes calldata interactiveData
     ) external returns(uint256) {
         if(interactiveData[0] == _FINALIZE_INTERACTION) {


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2022-06-28 at 18 10 01" src="https://user-images.githubusercontent.com/22360160/176165030-808ce8e5-c7a4-4fab-b7b8-7f0fcabb2578.png">

fillOrder +0 +100 +8 gas execution cost

RecursiveMatcher.matchOrders +277 +423 +325 gas execution cost