### PR TITLE
Optimize OrderRFQ hash computation with assembly

### DIFF
--- a/contracts/OrderLib.sol
+++ b/contracts/OrderLib.sol
@@ -104,15 +104,17 @@ library OrderLib {
         assembly { // solhint-disable-line no-inline-assembly
             let ptr := mload(0x40)
 
+            // keccak256(abi.encode(_LIMIT_ORDER_TYPEHASH, orderWithoutInteractions, keccak256(order.interactions)));
             calldatacopy(ptr, interactions.offset, interactions.length)
             mstore(add(ptr, 0x140), keccak256(ptr, interactions.length))
             calldatacopy(add(ptr, 0x20), order, 0x120)
             mstore(ptr, typehash)
-            result := keccak256(ptr, 0x160)
+            let orderHash := keccak256(ptr, 0x160)
 
-            mstore(ptr, 0x1901000000000000000000000000000000000000000000000000000000000000) // "\x19\x01"
+            // ECDSA.toTypedDataHash(domainSeparator, orderHash)
+            mstore(ptr, 0x1901000000000000000000000000000000000000000000000000000000000000)
             mstore(add(ptr, 0x02), domainSeparator)
-            mstore(add(ptr, 0x22), result)
+            mstore(add(ptr, 0x22), orderHash)
             result := keccak256(ptr, 66)
         }
     }

--- a/contracts/OrderRFQLib.sol
+++ b/contracts/OrderRFQLib.sol
@@ -25,7 +25,7 @@ library OrderRFQLib {
         ")"
     );
 
-    function hash(OrderRFQ memory order) internal pure returns(bytes32 result) {
+    function hash(OrderRFQ memory order, bytes32 domainSeparator) internal pure returns(bytes32 result) {
         // return keccak256(abi.encode(_LIMIT_ORDER_RFQ_TYPEHASH, order));
         bytes32 typehash = _LIMIT_ORDER_RFQ_TYPEHASH;
         assembly { // solhint-disable-line no-inline-assembly
@@ -40,6 +40,11 @@ library OrderRFQLib {
             mstore(add(ptr, 0xc0), mload(add(order, 0xa0)))
             mstore(add(ptr, 0xe0), mload(add(order, 0xc0)))
             result := keccak256(ptr, 0x100)
+
+            mstore(ptr, 0x1901000000000000000000000000000000000000000000000000000000000000) // "\x19\x01"
+            mstore(add(ptr, 0x02), domainSeparator)
+            mstore(add(ptr, 0x22), result)
+            result := keccak256(ptr, 66)
         }
     }
 }

--- a/contracts/OrderRFQLib.sol
+++ b/contracts/OrderRFQLib.sol
@@ -26,11 +26,11 @@ library OrderRFQLib {
     );
 
     function hash(OrderRFQ memory order, bytes32 domainSeparator) internal pure returns(bytes32 result) {
-        // return keccak256(abi.encode(_LIMIT_ORDER_RFQ_TYPEHASH, order));
         bytes32 typehash = _LIMIT_ORDER_RFQ_TYPEHASH;
         assembly { // solhint-disable-line no-inline-assembly
             let ptr := mload(0x40)
 
+            // keccak256(abi.encode(_LIMIT_ORDER_RFQ_TYPEHASH, order));
             mstore(ptr, typehash)
             mstore(add(ptr, 0x20), mload(order))
             mstore(add(ptr, 0x40), mload(add(order, 0x20)))
@@ -39,11 +39,12 @@ library OrderRFQLib {
             mstore(add(ptr, 0xa0), mload(add(order, 0x80)))
             mstore(add(ptr, 0xc0), mload(add(order, 0xa0)))
             mstore(add(ptr, 0xe0), mload(add(order, 0xc0)))
-            result := keccak256(ptr, 0x100)
+            let orderHash := keccak256(ptr, 0x100)
 
+            // ECDSA.toTypedDataHash(domainSeparator, orderHash)
             mstore(ptr, 0x1901000000000000000000000000000000000000000000000000000000000000) // "\x19\x01"
             mstore(add(ptr, 0x02), domainSeparator)
-            mstore(add(ptr, 0x22), result)
+            mstore(add(ptr, 0x22), orderHash)
             result := keccak256(ptr, 66)
         }
     }

--- a/contracts/OrderRFQLib.sol
+++ b/contracts/OrderRFQLib.sol
@@ -42,7 +42,7 @@ library OrderRFQLib {
             let orderHash := keccak256(ptr, 0x100)
 
             // ECDSA.toTypedDataHash(domainSeparator, orderHash)
-            mstore(ptr, 0x1901000000000000000000000000000000000000000000000000000000000000) // "\x19\x01"
+            mstore(ptr, 0x1901000000000000000000000000000000000000000000000000000000000000)
             mstore(add(ptr, 0x02), domainSeparator)
             mstore(add(ptr, 0x22), orderHash)
             result := keccak256(ptr, 66)

--- a/contracts/OrderRFQLib.sol
+++ b/contracts/OrderRFQLib.sol
@@ -13,7 +13,7 @@ library OrderRFQLib {
         uint256 takingAmount;
     }
 
-    bytes32 constant public LIMIT_ORDER_RFQ_TYPEHASH = keccak256(
+    bytes32 constant internal _LIMIT_ORDER_RFQ_TYPEHASH = keccak256(
         "OrderRFQ("
             "uint256 info,"
             "address makerAsset,"
@@ -25,7 +25,21 @@ library OrderRFQLib {
         ")"
     );
 
-    function hash(OrderRFQ memory order) internal pure returns(bytes32) {
-        return keccak256(abi.encode(LIMIT_ORDER_RFQ_TYPEHASH, order));
+    function hash(OrderRFQ memory order) internal pure returns(bytes32 result) {
+        // return keccak256(abi.encode(_LIMIT_ORDER_RFQ_TYPEHASH, order));
+        bytes32 typehash = _LIMIT_ORDER_RFQ_TYPEHASH;
+        assembly { // solhint-disable-line no-inline-assembly
+            let ptr := mload(0x40)
+
+            mstore(ptr, typehash)
+            mstore(add(ptr, 0x20), mload(order))
+            mstore(add(ptr, 0x40), mload(add(order, 0x20)))
+            mstore(add(ptr, 0x60), mload(add(order, 0x40)))
+            mstore(add(ptr, 0x80), mload(add(order, 0x60)))
+            mstore(add(ptr, 0xa0), mload(add(order, 0x80)))
+            mstore(add(ptr, 0xc0), mload(add(order, 0xa0)))
+            mstore(add(ptr, 0xe0), mload(add(order, 0xc0)))
+            result := keccak256(ptr, 0x100)
+        }
     }
 }

--- a/contracts/OrderRFQMixin.sol
+++ b/contracts/OrderRFQMixin.sol
@@ -78,7 +78,7 @@ abstract contract OrderRFQMixin is EIP712, AmountCalculator {
         bytes32 vs,
         uint256 amount
     ) external returns(uint256 filledMakingAmount, uint256 filledTakingAmount, bytes32 orderHash) {
-        orderHash = _hashTypedDataV4(order.hash());
+        orderHash = order.hash(_domainSeparatorV4());
         if (amount & _SIGNER_SMART_CONTRACT_HINT != 0) {
             if (amount & _IS_VALID_SIGNATURE_65_BYTES != 0) {
                 require(ECDSA.isValidSignature65(order.maker, orderHash, r, vs), "LOP: bad signature");
@@ -132,7 +132,7 @@ abstract contract OrderRFQMixin is EIP712, AmountCalculator {
         uint256 takingAmount,
         address target
     ) public returns(uint256 filledMakingAmount, uint256 filledTakingAmount, bytes32 orderHash) {
-        orderHash = _hashTypedDataV4(order.hash());
+        orderHash = order.hash(_domainSeparatorV4());
         if (!ECDSA.recoverOrIsValidSignature(order.maker, orderHash, signature)) revert RFQBadSignature();
         (filledMakingAmount, filledTakingAmount) = _fillOrderRFQTo(order, makingAmount, takingAmount, target);
         emit OrderFilledRFQ(orderHash, filledMakingAmount);

--- a/contracts/mocks/ContractRFQ.sol
+++ b/contracts/mocks/ContractRFQ.sol
@@ -87,6 +87,6 @@ contract ContractRFQ is IERC1271, EIP712Alien, ERC20 {
     }
 
     function _hash(OrderRFQLib.OrderRFQ memory order) internal view returns(bytes32) {
-        return _hashTypedDataV4(order.hash());
+        return order.hash(_domainSeparatorV4());
     }
 }


### PR DESCRIPTION
```
·································|·············|·············|·················|···············|
|  Method                        ·  Min        ·  Max        ·  Avg            ·  # calls      ·
·································|·············|·············|·················|···············|
|  fillOrderRFQ                  ·      80944  ·     100471  ·          94827  ·            7  ·
·································|·············|·············|·················|···············|
|  fillOrderRFQCompact           ·      82261  ·      99407  ·          95912  ·            5  ·
·································|·············|·············|·················|···············|
|  fillOrderRFQToWithPermit      ·     130477  ·     130593  ·         130535  ·            2  ·
·································|·············|·············|·················|···············|
```
=>
```
·································|·············|·············|·················|···············|
|  Method                        ·  Min        ·  Max        ·  Avg            ·  # calls      ·
·································|·············|·············|·················|···············|
|  fillOrderRFQ                  ·      80347  ·     100163  ·          94436  ·            7  ·
·································|·············|·············|·················|···············|
|  fillOrderRFQCompact           ·      81953  ·      99099  ·          95604  ·            5  ·
·································|·············|·············|·················|···············|
|  fillOrderRFQToWithPermit      ·     130169  ·     130285  ·         130227  ·            2  ·
·································|·············|·············|·················|···············|
```