### PR TITLE
Remove maker from OrderRFQ

### DIFF
--- a/contracts/OrderRFQLib.sol
+++ b/contracts/OrderRFQLib.sol
@@ -10,7 +10,6 @@ library OrderRFQLib {
         uint256 info;  // lowest 64 bits is the order id, next 64 bits is the expiration timestamp
         Address makerAsset;
         Address takerAsset;
-        Address maker;
         Address allowedSender;  // equals to Zero address on public orders
         uint256 makingAmount;
         uint256 takingAmount;
@@ -21,7 +20,6 @@ library OrderRFQLib {
             "uint256 info,"
             "address makerAsset,"
             "address takerAsset,"
-            "address maker,"
             "address allowedSender,"
             "uint256 makingAmount,"
             "uint256 takingAmount"
@@ -36,8 +34,8 @@ library OrderRFQLib {
 
             // keccak256(abi.encode(_LIMIT_ORDER_RFQ_TYPEHASH, order));
             mstore(ptr, typehash)
-            calldatacopy(add(ptr, 0x20), order, 0xe0)
-            result := keccak256(ptr, 0x100)
+            calldatacopy(add(ptr, 0x20), order, 0xc0)
+            result := keccak256(ptr, 0xe0)
         }
         result = ECDSA.toTypedDataHash(domainSeparator, result);
     }

--- a/contracts/OrderRFQMixin.sol
+++ b/contracts/OrderRFQMixin.sol
@@ -121,7 +121,7 @@ abstract contract OrderRFQMixin is IOrderRFQMixin, EIP712, OnlyWethReceiver {
     function fillContractOrderRFQToWithPermit(
         OrderRFQLib.OrderRFQ calldata order,
         bytes calldata signature,
-        address maker,
+        Address maker,
         uint256 flagsAndAmount,
         bytes calldata interaction,
         address target,
@@ -134,8 +134,8 @@ abstract contract OrderRFQMixin is IOrderRFQMixin, EIP712, OnlyWethReceiver {
             target = msg.sender;
         }
         orderHash = order.hash(_domainSeparatorV4());
-        if (!ECDSA.isValidSignature(maker, orderHash, signature)) revert RFQBadSignature();
-        (filledMakingAmount, filledTakingAmount) = _fillOrderRFQTo(order, maker, flagsAndAmount, interaction, target);
+        if (!ECDSA.isValidSignature(maker.get(), orderHash, signature)) revert RFQBadSignature();
+        (filledMakingAmount, filledTakingAmount) = _fillOrderRFQTo(order, maker.get(), flagsAndAmount, interaction, target);
         emit OrderFilledRFQ(orderHash, filledMakingAmount);
     }
 

--- a/contracts/interfaces/IOrderRFQMixin.sol
+++ b/contracts/interfaces/IOrderRFQMixin.sol
@@ -24,7 +24,8 @@ interface IOrderRFQMixin {
         uint256 makingAmount
     );
 
-     /* @notice Returns bitmask for double-spend invalidators based on lowest byte of order.info and filled quotes
+    /**
+     * @notice Returns bitmask for double-spend invalidators based on lowest byte of order.info and filled quotes
      * @param maker Maker address
      * @param slot Slot number to return bitmask for
      * @return result Each bit represents whether corresponding was already invalidated
@@ -37,48 +38,69 @@ interface IOrderRFQMixin {
      */
     function cancelOrderRFQ(uint256 orderInfo) external;
 
-    /// @notice Cancels multiple order's quotes
+    /**
+     * @notice Cancels multiple order's quotes
+     */
     function cancelOrderRFQ(uint256 orderInfo, uint256 additionalMask) external;
 
     /**
      * @notice Fills order's quote, fully or partially (whichever is possible)
      * @param order Order quote to fill
-     * @param signature Signature to confirm quote ownership
-     * @param interaction A call data for InteractiveNotificationReceiver. Taker may execute interaction after getting maker assets and before sending taker assets.
+     * @param r R component of signature
+     * @param vs VS component of signature
      * @param flagsAndAmount Fill configuration flags with amount packed in one slot
+     * @return filledMakingAmount Actual amount transferred from maker to taker
+     * @return filledTakingAmount Actual amount transferred from taker to maker
+     * @return orderHash Hash of the filled order
+     */
+    function fillRFQ(
+        OrderRFQLib.OrderRFQ calldata order,
+        bytes32 r,
+        bytes32 vs,
+        uint256 flagsAndAmount
+    ) external payable returns(uint256 filledMakingAmount, uint256 filledTakingAmount, bytes32 orderHash);
+
+    /**
+     * @notice Fills order's quote, fully or partially (whichever is possible)
+     * @param order Order quote to fill
+     * @param r R component of signature
+     * @param vs VS component of signature
+     * @param flagsAndAmount Fill configuration flags with amount packed in one slot
+     * - Bits 0-253 contain the amount to fill
+     * - Bit 254 is used to indicate whether weth should be unwrapped to eth
+     * - Bit 255 is used to indicate whether maker (1) or taker amount (0) is given in the amount parameter
+     * @param interaction A call data for InteractiveNotificationReceiver. Taker may execute interaction after getting maker assets and before sending taker assets.
      * @return filledMakingAmount Actual amount transferred from maker to taker
      * @return filledTakingAmount Actual amount transferred from taker to maker
      * @return orderHash Hash of the filled order
      */
     function fillOrderRFQ(
         OrderRFQLib.OrderRFQ calldata order,
-        bytes calldata signature,
-        bytes calldata interaction,
-        uint256 flagsAndAmount
+        bytes32 r,
+        bytes32 vs,
+        uint256 flagsAndAmount,
+        bytes calldata interaction
     ) external payable returns(uint256 filledMakingAmount, uint256 filledTakingAmount, bytes32 orderHash);
 
     /**
-     * @notice Fills order's quote, fully or partially, with compact signature
+     * @notice Same as `fillOrderRFQ` but allows to specify funds destination instead of `msg.sender`
      * @param order Order quote to fill
      * @param r R component of signature
      * @param vs VS component of signature
-     * @param interaction A call data for InteractiveNotificationReceiver. Taker may execute interaction after getting maker assets and before sending taker assets.
      * @param flagsAndAmount Fill configuration flags with amount packed in one slot
-     * - Bits 0-251 contain the amount to fill
-     * - Bit 252 is used to indicate whether weth should be unwrapped to eth
-     * - Bit 253 is used to indicate whether signature is 64-bit (0) or 65-bit (1)
-     * - Bit 254 is used to indicate whether smart contract (1) signed the order or not (0)
-     * - Bit 255 is used to indicate whether maker (1) or taker amount (0) is given in the amount parameter
+     * @param interaction A call data for InteractiveNotificationReceiver. Taker may execute interaction after getting maker assets and before sending taker assets.
+     * @param target Address that will receive swap funds
      * @return filledMakingAmount Actual amount transferred from maker to taker
      * @return filledTakingAmount Actual amount transferred from taker to maker
      * @return orderHash Hash of the filled order
      */
-    function fillOrderRFQCompact(
+    function fillOrderRFQTo(
         OrderRFQLib.OrderRFQ calldata order,
         bytes32 r,
         bytes32 vs,
+        uint256 flagsAndAmount,
         bytes calldata interaction,
-        uint256 flagsAndAmount
+        address target
     ) external payable returns(uint256 filledMakingAmount, uint256 filledTakingAmount, bytes32 orderHash);
 
     /**
@@ -86,9 +108,10 @@ interface IOrderRFQMixin {
      * It allows to approve token spending and make a swap in one transaction.
      * Also allows to specify funds destination instead of `msg.sender`
      * @param order Order quote to fill
-     * @param signature Signature to confirm quote ownership
-     * @param interaction A call data for InteractiveNotificationReceiver. Taker may execute interaction after getting maker assets and before sending taker assets.
+     * @param r R component of signature
+     * @param vs VS component of signature
      * @param flagsAndAmount Fill configuration flags with amount packed in one slot
+     * @param interaction A call data for InteractiveNotificationReceiver. Taker may execute interaction after getting maker assets and before sending taker assets.
      * @param target Address that will receive swap funds
      * @param permit Should contain abi-encoded calldata for `IERC20Permit.permit` call
      * @return filledMakingAmount Actual amount transferred from maker to taker
@@ -98,28 +121,37 @@ interface IOrderRFQMixin {
      */
     function fillOrderRFQToWithPermit(
         OrderRFQLib.OrderRFQ calldata order,
-        bytes calldata signature,
-        bytes calldata interaction,
+        bytes32 r,
+        bytes32 vs,
         uint256 flagsAndAmount,
+        bytes calldata interaction,
         address target,
         bytes calldata permit
     ) external returns(uint256 filledMakingAmount, uint256 filledTakingAmount, bytes32 orderHash);
 
     /**
-     * @notice Same as `fillOrderRFQ` but allows to specify funds destination instead of `msg.sender`
+     * @notice Same as `fillOrderRFQTo` but calls permit first.
+     * It allows to approve token spending and make a swap in one transaction.
+     * Also allows to specify funds destination instead of `msg.sender`
      * @param order Order quote to fill
      * @param signature Signature to confirm quote ownership
+     * @param maker Smart contract that signed the order
      * @param flagsAndAmount Fill configuration flags with amount packed in one slot
+     * @param interaction A call data for InteractiveNotificationReceiver. Taker may execute interaction after getting maker assets and before sending taker assets.
      * @param target Address that will receive swap funds
+     * @param permit Should contain abi-encoded calldata for `IERC20Permit.permit` call
      * @return filledMakingAmount Actual amount transferred from maker to taker
      * @return filledTakingAmount Actual amount transferred from taker to maker
      * @return orderHash Hash of the filled order
+     * @dev See tests for examples
      */
-    function fillOrderRFQTo(
+    function fillContractOrderRFQToWithPermit(
         OrderRFQLib.OrderRFQ calldata order,
         bytes calldata signature,
-        bytes calldata interaction,
+        address maker,
         uint256 flagsAndAmount,
-        address target
-    ) external payable returns(uint256 filledMakingAmount, uint256 filledTakingAmount, bytes32 orderHash);
+        bytes calldata interaction,
+        address target,
+        bytes calldata permit
+    ) external returns(uint256 filledMakingAmount, uint256 filledTakingAmount, bytes32 orderHash);
 }

--- a/contracts/interfaces/IOrderRFQMixin.sol
+++ b/contracts/interfaces/IOrderRFQMixin.sol
@@ -148,7 +148,7 @@ interface IOrderRFQMixin {
     function fillContractOrderRFQToWithPermit(
         OrderRFQLib.OrderRFQ calldata order,
         bytes calldata signature,
-        address maker,
+        Address maker,
         uint256 flagsAndAmount,
         bytes calldata interaction,
         address target,

--- a/contracts/mocks/ContractRFQ.sol
+++ b/contracts/mocks/ContractRFQ.sol
@@ -71,7 +71,7 @@ contract ContractRFQ is IERC1271, EIP712Alien, ERC20 {
     }
 
     function isValidSignature(bytes32 hash, bytes calldata signature) external view override returns(bytes4) {
-        if (signature.length != 32 * 7) revert MalformedSignature();
+        if (signature.length != 32 * 6) revert MalformedSignature();
 
         OrderRFQLib.OrderRFQ calldata order;
         assembly { // solhint-disable-line no-inline-assembly
@@ -84,7 +84,6 @@ contract ContractRFQ is IERC1271, EIP712Alien, ERC20 {
                 (order.makerAsset.get() != address(token1) || order.takerAsset.get() != address(token0))
             ) ||
             order.makingAmount * fee > order.takingAmount * 1e18 ||
-            order.maker.get() != address(this) || // TODO: remove redundant check
             order.hash(_domainSeparatorV4()) != hash
         ) revert BadPrice();
 

--- a/contracts/mocks/RecursiveMatcher.sol
+++ b/contracts/mocks/RecursiveMatcher.sol
@@ -36,15 +36,17 @@ contract RecursiveMatcher is IInteractionNotificationReceiver {
     function matchRfqOrders(
         IOrderRFQMixin orderRFQMixin,
         OrderRFQLib.OrderRFQ calldata order,
-        bytes calldata signature,
-        bytes calldata interaction,
-        uint256 flagsAndAmount
+        bytes32 r,
+        bytes32 vs,
+        uint256 flagsAndAmount,
+        bytes calldata interaction
     ) external {
         orderRFQMixin.fillOrderRFQ(
             order,
-            signature,
-            interaction,
-            flagsAndAmount
+            r,
+            vs,
+            flagsAndAmount,
+            interaction
         );
     }
 
@@ -70,16 +72,18 @@ contract RecursiveMatcher is IInteractionNotificationReceiver {
             if(interactiveData[0] & _RFQ_FLAG != 0x0) {
                 (
                     OrderRFQLib.OrderRFQ memory order,
-                    bytes memory signature,
-                    bytes memory interaction,
-                    uint256 flagsAndAmount
-                ) = abi.decode(interactiveData[1:], (OrderRFQLib.OrderRFQ, bytes, bytes, uint256));
+                    bytes32 r,
+                    bytes32 vs,
+                    uint256 flagsAndAmount,
+                    bytes memory interaction
+                ) = abi.decode(interactiveData[1:], (OrderRFQLib.OrderRFQ, bytes32, bytes32, uint256, bytes));
 
                 IOrderRFQMixin(msg.sender).fillOrderRFQ(
                     order,
-                    signature,
-                    interaction,
-                    flagsAndAmount
+                    r,
+                    vs,
+                    flagsAndAmount,
+                    interaction
                 );
             } else {
                 (

--- a/test/ContractRFQ.js
+++ b/test/ContractRFQ.js
@@ -4,8 +4,10 @@ const { ABIOrderRFQ, buildOrderRFQ, makingAmount } = require('./helpers/orderUti
 const { ethers } = require('hardhat');
 const { ether } = require('./helpers/utils');
 const { deploySwap, deployUSDC, deployUSDT } = require('./helpers/fixtures');
+const { constants } = require('ethers');
 
 describe('ContractRFQ', function () {
+    const emptyInteraction = '0x';
     const abiCoder = ethers.utils.defaultAbiCoder;
     let addr;
 
@@ -40,20 +42,19 @@ describe('ContractRFQ', function () {
         const takerUsdc = await usdc.balanceOf(addr.address);
         const makerUsdt = await usdt.balanceOf(rfq.address);
         const takerUsdt = await usdt.balanceOf(addr.address);
-        const emptyInteraction = '0x';
 
-        const order = buildOrderRFQ('1', usdc.address, usdt.address, 1000000000, 1000700000, rfq.address);
+        const order = buildOrderRFQ('1', usdc.address, usdt.address, 1000000000, 1000700000);
 
         const signature = abiCoder.encode([ABIOrderRFQ], [order]);
-        await swap.fillOrderRFQ(order, signature, emptyInteraction, makingAmount(1000000));
+        await swap.fillContractOrderRFQToWithPermit(order, signature, rfq.address, makingAmount(1000000), emptyInteraction, constants.AddressZero, '0x');
 
         expect(await usdc.balanceOf(rfq.address)).to.equal(makerUsdc.sub(1000000));
         expect(await usdc.balanceOf(addr.address)).to.equal(takerUsdc.add(1000000));
         expect(await usdt.balanceOf(rfq.address)).to.equal(makerUsdt.add(1000700));
         expect(await usdt.balanceOf(addr.address)).to.equal(takerUsdt.sub(1000700));
 
-        const order2 = buildOrderRFQ('2', usdc.address, usdt.address, 1000000000, 1000700000, rfq.address);
+        const order2 = buildOrderRFQ('2', usdc.address, usdt.address, 1000000000, 1000700000);
         const signature2 = abiCoder.encode([ABIOrderRFQ], [order2]);
-        await swap.fillOrderRFQ(order2, signature2, emptyInteraction, makingAmount(1000000));
+        await swap.fillContractOrderRFQToWithPermit(order2, signature2, rfq.address, makingAmount(1000000), emptyInteraction, constants.AddressZero, '0x');
     });
 });

--- a/test/helpers/orderUtils.js
+++ b/test/helpers/orderUtils.js
@@ -6,7 +6,6 @@ const OrderRFQ = [
     { name: 'info', type: 'uint256' },
     { name: 'makerAsset', type: 'address' },
     { name: 'takerAsset', type: 'address' },
-    { name: 'maker', type: 'address' },
     { name: 'allowedSender', type: 'address' },
     { name: 'makingAmount', type: 'uint256' },
     { name: 'takingAmount', type: 'uint256' },
@@ -108,14 +107,12 @@ function buildOrderRFQ (
     takerAsset,
     makingAmount,
     takingAmount,
-    from,
     allowedSender = constants.ZERO_ADDRESS,
 ) {
     return {
         info,
         makerAsset,
         takerAsset,
-        maker: from,
         allowedSender,
         makingAmount,
         takingAmount,
@@ -157,7 +154,7 @@ function compactSignature (signature) {
 }
 
 function unwrapWeth (amount) {
-    return setn(BigInt(amount), 252, 1).toString();
+    return setn(BigInt(amount), 254, 1).toString();
 }
 
 function makingAmount (amount) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3768,7 +3768,7 @@ inquirer@^6.2.2:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-internal-slot@^1.0.4:
+internal-slot@^1.0.3, internal-slot@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.4.tgz#8551e7baf74a7a6ba5f749cfb16aa60722f0d6f3"
   integrity sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==
@@ -5568,7 +5568,7 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string.prototype.trimend@^1.0.6:
+string.prototype.trimend@^1.0.5, string.prototype.trimend@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
   integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
@@ -5577,7 +5577,7 @@ string.prototype.trimend@^1.0.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-string.prototype.trimstart@^1.0.6:
+string.prototype.trimstart@^1.0.5, string.prototype.trimstart@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
   integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==


### PR DESCRIPTION
Run only tests from `RfqOrders.js`.

```
·······················|····························|··········|··········|··········|······
|  LimitOrderProtocol  ·  fillOrderRFQ              ·   82158  ·  119965  ·  100677  ·  7  │
·······················|····························|··········|··········|··········|······
|  LimitOrderProtocol  ·  fillOrderRFQCompact       ·   81457  ·   98594  ·   95112  ·  5  │
·······················|····························|··········|··········|··········|······
|  LimitOrderProtocol  ·  fillOrderRFQToWithPermit  ·  126801  ·  126910  ·  126856  ·  2  │
·······················|····························|··········|··········|··········|······
```
=>
```
·······················|····························|··········|··········|··········|·······
|  LimitOrderProtocol  ·  fillRFQ                   ·   80277  ·  118045  ·   98321  ·  10  │
·······················|····························|··········|··········|··········|·······
|  LimitOrderProtocol  ·  fillOrderRFQToWithPermit  ·  125488  ·  125612  ·  125550  ·   2  │
·······················|····························|··········|··········|··········|·······
```