### PR TITLE
Much cheaper order cancelling

### DIFF
--- a/contracts/OrderMixin.sol
+++ b/contracts/OrderMixin.sol
@@ -30,9 +30,10 @@ abstract contract OrderMixin is IOrderMixin, EIP712, PredicateHelper {
     uint256 private constant _ORDER_FILLED = 1;
 
     IWETH private immutable _WETH;  // solhint-disable-line var-name-mixedcase
+
     /// @notice Stores unfilled amounts for each order plus one.
     /// Therefore 0 means order doesn't exist and 1 means order was filled
-    mapping(bytes32 => uint256) private _remaining;
+    mapping(address => mapping(bytes32 => uint256)) private _remaining;
 
     constructor(IWETH weth) {
         _WETH = weth;
@@ -41,8 +42,8 @@ abstract contract OrderMixin is IOrderMixin, EIP712, PredicateHelper {
     /**
      * @notice See {IOrderMixin-remaining}.
      */
-    function remaining(bytes32 orderHash) external view returns(uint256 /* amount */) {
-        uint256 amount = _remaining[orderHash];
+    function remaining(address maker, bytes32 orderHash) external view returns(uint256 /* amount */) {
+        uint256 amount = _remaining[maker][orderHash];
         if (amount == _ORDER_DOES_NOT_EXIST) revert UnknownOrder();
         unchecked { return amount - 1; }
     }
@@ -50,17 +51,17 @@ abstract contract OrderMixin is IOrderMixin, EIP712, PredicateHelper {
     /**
      * @notice See {IOrderMixin-remainingRaw}.
      */
-    function remainingRaw(bytes32 orderHash) external view returns(uint256 /* rawAmount */) {
-        return _remaining[orderHash];
+    function remainingRaw(address maker, bytes32 orderHash) external view returns(uint256 /* rawAmount */) {
+        return _remaining[maker][orderHash];
     }
 
     /**
      * @notice See {IOrderMixin-remainingsRaw}.
      */
-    function remainingsRaw(bytes32[] memory orderHashes) external view returns(uint256[] memory /* rawAmounts */) {
+    function remainingsRaw(address[] calldata makers, bytes32[] calldata orderHashes) external view returns(uint256[] memory /* rawAmounts */) {
         uint256[] memory results = new uint256[](orderHashes.length);
         for (uint256 i = 0; i < orderHashes.length; i++) {
-            results[i] = _remaining[orderHashes[i]];
+            results[i] = _remaining[makers[i]][orderHashes[i]];
         }
         return results;
     }
@@ -77,14 +78,19 @@ abstract contract OrderMixin is IOrderMixin, EIP712, PredicateHelper {
     /**
      * @notice See {IOrderMixin-cancelOrder}.
      */
-    function cancelOrder(OrderLib.Order calldata order) external returns(uint256 orderRemaining, bytes32 orderHash) {
-        if (order.maker.get() != msg.sender) revert AccessDenied();
+    function cancelOrder(bytes32 orderHash) public returns(uint256 orderRemaining) {
+        return _cancelOrder(_remaining[msg.sender], orderHash);
+    }
 
-        orderHash = hashOrder(order);
-        orderRemaining = _remaining[orderHash];
-        if (orderRemaining == _ORDER_FILLED) revert AlreadyFilled();
-        emit OrderCanceled(msg.sender, orderHash, orderRemaining);
-        _remaining[orderHash] = _ORDER_FILLED;
+    /**
+     * @notice See {IOrderMixin-cancelOrders}.
+     */
+    function cancelOrders(bytes32[] calldata orderHashes) external returns(uint256[] memory orderRemaining) {
+        orderRemaining = new uint256[](orderHashes.length);
+        mapping(bytes32 => uint256) storage remainingPtr = _remaining[msg.sender];
+        for (uint256 i = 0; i < orderHashes.length; i++) {
+            orderRemaining[i] = _cancelOrder(remainingPtr, orderHashes[i]);
+        }
     }
 
     /**
@@ -140,7 +146,8 @@ abstract contract OrderMixin is IOrderMixin, EIP712, PredicateHelper {
         if (!nonceEquals(order.maker.get(), order.constraints.series(), order.constraints.nonce())) revert WrongSeriesNonce();
 
         orderHash = hashOrder(order);
-        uint256 remainingMakingAmount = _remaining[orderHash];
+        mapping(bytes32 => uint256) storage remainingPtr = _remaining[order.maker.get()];
+        uint256 remainingMakingAmount = remainingPtr[orderHash];
         if (remainingMakingAmount == _ORDER_FILLED) revert RemainingAmountIsZero();
         if (remainingMakingAmount == _ORDER_DOES_NOT_EXIST) {
             // First fill: validate order and permit maker asset
@@ -154,7 +161,7 @@ abstract contract OrderMixin is IOrderMixin, EIP712, PredicateHelper {
                     address token = address(bytes20(permit));
                     bytes calldata permitCalldata = permit[20:];
                     IERC20(token).safePermit(permitCalldata); // TODO: inline both arguments
-                    if (_remaining[orderHash] != _ORDER_DOES_NOT_EXIST) revert ReentrancyDetected();
+                    if (remainingPtr[orderHash] != _ORDER_DOES_NOT_EXIST) revert ReentrancyDetected();
                 }
             }
         } else {
@@ -206,7 +213,7 @@ abstract contract OrderMixin is IOrderMixin, EIP712, PredicateHelper {
         // Update remaining amount in storage
         unchecked {
             remainingMakingAmount = remainingMakingAmount - actualMakingAmount;
-            _remaining[orderHash] = remainingMakingAmount + 1;
+            remainingPtr[orderHash] = remainingMakingAmount + 1;
         }
         emit OrderFilled(order.maker.get(), orderHash, remainingMakingAmount);
 
@@ -293,6 +300,13 @@ abstract contract OrderMixin is IOrderMixin, EIP712, PredicateHelper {
      */
     function hashOrder(OrderLib.Order calldata order) public view returns(bytes32) {
         return order.hash(_domainSeparatorV4());
+    }
+
+    function _cancelOrder(mapping(bytes32 => uint256) storage remainingPtr, bytes32 orderHash) private returns(uint256 orderRemaining) {
+        orderRemaining = remainingPtr[orderHash];
+        if (orderRemaining == _ORDER_FILLED) revert AlreadyFilled();
+        emit OrderCanceled(msg.sender, orderHash, orderRemaining);
+        remainingPtr[orderHash] = _ORDER_FILLED;
     }
 
     function _callTransferFrom(address asset, address from, address to, uint256 amount, bytes calldata input) private returns(bool success) {

--- a/contracts/interfaces/IOrderMixin.sol
+++ b/contracts/interfaces/IOrderMixin.sol
@@ -9,7 +9,6 @@ interface IOrderMixin {
     error WrongNonce();
     error WrongSeriesNonce();
     error UnknownOrder();
-    error AccessDenied();
     error AlreadyFilled();
     error PermitLengthTooLow();
     error RemainingAmountIsZero();
@@ -42,24 +41,27 @@ interface IOrderMixin {
 
     /**
      * @notice Returns unfilled amount for order. Throws if order does not exist
+     * @param maker Maker address
      * @param orderHash Order's hash. Can be obtained by the `hashOrder` function
      * @return amount Unfilled amount
      */
-    function remaining(bytes32 orderHash) external view returns(uint256 amount);
+    function remaining(address maker, bytes32 orderHash) external view returns(uint256 amount);
 
     /**
      * @notice Returns unfilled amount for order
+     * @param maker Maker address
      * @param orderHash Order's hash. Can be obtained by the `hashOrder` function
      * @return rawAmount Unfilled amount of order plus one if order exists. Otherwise 0
      */
-    function remainingRaw(bytes32 orderHash) external view returns(uint256 rawAmount);
+    function remainingRaw(address maker, bytes32 orderHash) external view returns(uint256 rawAmount);
 
     /**
      * @notice Same as `remainingRaw` but for multiple orders
+     * @param makers Array of makers addresses
      * @param orderHashes Array of hashes
      * @return rawAmounts Array of amounts for each order plus one if order exists or 0 otherwise
      */
-    function remainingsRaw(bytes32[] memory orderHashes) external view returns(uint256[] memory rawAmounts);
+    function remainingsRaw(address[] calldata makers, bytes32[] calldata orderHashes) external view returns(uint256[] memory rawAmounts);
 
     /**
      * @notice Checks order predicate
@@ -84,13 +86,20 @@ interface IOrderMixin {
     function simulate(address target, bytes calldata data) external;
 
     /**
-     * @notice Cancels order.
+     * @notice Cancels order of msg.sender
      * @dev Order is cancelled by setting remaining amount to _ORDER_FILLED value
-     * @param order Order quote to cancel
+     * @param orderHash Hash of the order to cancel
      * @return orderRemaining Unfilled amount of order before cancellation
-     * @return orderHash Hash of the filled order
      */
-    function cancelOrder(OrderLib.Order calldata order) external returns(uint256 orderRemaining, bytes32 orderHash);
+    function cancelOrder(bytes32 orderHash) external returns(uint256 orderRemaining);
+
+    /**
+     * @notice Cancels multiple orders of msg.sender
+     * @dev Order is cancelled by setting remaining amount to _ORDER_FILLED value
+     * @param orderHashes Array of hashes of orders to cancel
+     * @return orderRemaining Array of unfilled amounts of orders before cancellation
+     */
+    function cancelOrders(bytes32[] calldata orderHashes) external returns(uint256[] memory orderRemaining);
 
     /**
      * @notice Fills an order. If one doesn't exist (first fill) it will be created using order.makerAssetData


### PR DESCRIPTION
Much cheaper on L2, but not that impressive for L1:

```
·······················|···············|·········|··········|··········|········
|  Contract            ·  Method       ·  Min    ·  Max     ·   Avg    · calls │
·······················|···············|·········|··········|··········|········
|  LimitOrderProtocol  ·  cancelOrder  ·      -  ·       -  ·   48740  ·    2  │
·······················|···············|·········|··········|··········|········
|  LimitOrderProtocol  ·  fillOrder    ·  79421  ·  130865  ·  104845  ·   39  │
·······················|···············|·········|··········|··········|········
```
=>
```
·······················|···············|·········|··········|··········|········
|  Contract            ·  Method       ·  Min    ·  Max     ·   Avg    · calls │
·······················|···············|·········|··········|··········|········
|  LimitOrderProtocol  ·  cancelOrder  ·  45715  ·   46087  ·   45963  ·    3  │
·······················|···············|·········|··········|··········|········
|  LimitOrderProtocol  ·  fillOrder    ·  79576  ·  131020  ·  105000  ·   39  │
·······················|···············|·········|··········|··········|········
```