### PR TITLE
Remove maker form order similarly to RFQ version

### DIFF
--- a/contracts/OrderLib.sol
+++ b/contracts/OrderLib.sol
@@ -19,7 +19,6 @@ library OrderLib {
         uint256 makingAmount;
         uint256 takingAmount;
         Constraints constraints;
-        Address maker;
         Address receiver;
         uint256 offsets;
         bytes interactions;
@@ -33,7 +32,6 @@ library OrderLib {
             "uint256 makingAmount,"
             "uint256 takingAmount,"
             "uint256 constraints,"
-            "address maker,"
             "address receiver,"
             "uint256 offsets,"
             "bytes interactions"
@@ -100,10 +98,10 @@ library OrderLib {
 
             // keccak256(abi.encode(_LIMIT_ORDER_TYPEHASH, orderWithoutInteractions, keccak256(order.interactions)));
             calldatacopy(ptr, interactions.offset, interactions.length)
-            mstore(add(ptr, 0x140), keccak256(ptr, interactions.length))
-            calldatacopy(add(ptr, 0x20), order, 0x120)
+            mstore(add(ptr, 0x120), keccak256(ptr, interactions.length))
+            calldatacopy(add(ptr, 0x20), order, 0x100)
             mstore(ptr, typehash)
-            result := keccak256(ptr, 0x160)
+            result := keccak256(ptr, 0x140)
         }
         result = ECDSA.toTypedDataHash(domainSeparator, result);
     }

--- a/contracts/mocks/RecursiveMatcher.sol
+++ b/contracts/mocks/RecursiveMatcher.sol
@@ -18,17 +18,21 @@ contract RecursiveMatcher is ITakerInteraction {
     function matchOrders(
         IOrderMixin orderMixin,
         OrderLib.Order calldata order,
-        bytes calldata signature,
-        bytes calldata interaction,
+        bytes32 r,
+        bytes32 vs,
         Input input,
-        uint256 thresholdAmount
+        uint256 threshold,
+        address target,
+        bytes calldata interaction
     ) external {
-        orderMixin.fillOrder(
+        orderMixin.fillOrderTo(
             order,
-            signature,
-            interaction,
+            r,
+            vs,
             input,
-            thresholdAmount
+            threshold,
+            target,
+            interaction
         );
     }
 
@@ -74,7 +78,7 @@ contract RecursiveMatcher is ITakerInteraction {
                 abi.encodePacked(
                     interactiveData[0] & _RFQ_FLAG != 0x0 ?
                         IOrderRFQMixin.fillOrderRFQTo.selector :
-                        IOrderMixin.fillOrder.selector,
+                        IOrderMixin.fillOrderTo.selector,
                     interactiveData[1:]
                 )
             );

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -17,7 +17,7 @@ module.exports = {
         settings: {
             optimizer: {
                 enabled: true,
-                runs: 1000000,
+                runs: 10_000,
             },
             viaIR: true,
         },

--- a/test/DutchAuctionCalculator.js
+++ b/test/DutchAuctionCalculator.js
@@ -2,7 +2,7 @@ const { expect, trim0x, time, assertRoughlyEqualValues } = require('@1inch/solid
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { cutLastArg, ether } = require('./helpers/utils');
 const { deploySwapTokens } = require('./helpers/fixtures');
-const { buildOrder, signOrder, makeMakingAmount } = require('./helpers/orderUtils');
+const { buildOrder, signOrder, makeMakingAmount, compactSignature } = require('./helpers/orderUtils');
 const { ethers } = require('hardhat');
 
 describe('Dutch auction', function () {
@@ -37,7 +37,6 @@ describe('Dutch auction', function () {
                 takerAsset: weth.address,
                 makingAmount: ether('100'),
                 takingAmount: ether('0.1'),
-                from: addr.address,
             },
             {
                 getMakingAmount: dutchAuctionCalculator.address + cutLastArg(trim0x(dutchAuctionCalculator.interface.encodeFunctionData('getMakingAmount',
@@ -61,7 +60,8 @@ describe('Dutch auction', function () {
         const { dai, weth, swap, ts, order, signature, makerDaiBefore, takerDaiBefore, makerWethBefore, takerWethBefore } = await loadFixture(deployAndBuildOrder);
 
         await time.increaseTo(ts + 43200n); // 50% auction time
-        await swap.connect(addr1).fillOrder(order, signature, '0x', makeMakingAmount(ether('100')), ether('0.08'));
+        const { r, vs } = compactSignature(signature);
+        await swap.connect(addr1).fillOrder(order, r, vs, makeMakingAmount(ether('100')), ether('0.08'));
 
         expect(await dai.balanceOf(addr.address)).to.equal(makerDaiBefore.sub(ether('100')));
         expect(await dai.balanceOf(addr1.address)).to.equal(takerDaiBefore.add(ether('100')));
@@ -73,7 +73,8 @@ describe('Dutch auction', function () {
         const { dai, weth, swap, ts, order, signature, makerDaiBefore, takerDaiBefore, makerWethBefore, takerWethBefore } = await loadFixture(deployAndBuildOrder);
 
         await time.increaseTo(ts + 43200n); // 50% auction time
-        await swap.connect(addr1).fillOrder(order, signature, '0x', ether('0.075'), ether('100'));
+        const { r, vs } = compactSignature(signature);
+        await swap.connect(addr1).fillOrder(order, r, vs, ether('0.075'), ether('100'));
 
         expect(await dai.balanceOf(addr.address)).to.equal(makerDaiBefore.sub(ether('100')));
         expect(await dai.balanceOf(addr1.address)).to.equal(takerDaiBefore.add(ether('100')));
@@ -84,7 +85,8 @@ describe('Dutch auction', function () {
     it('swap with makingAmount 0% time passed', async function () {
         const { dai, weth, swap, order, signature, makerDaiBefore, takerDaiBefore, makerWethBefore, takerWethBefore } = await loadFixture(deployAndBuildOrder);
 
-        await swap.connect(addr1).fillOrder(order, signature, '0x', makeMakingAmount(ether('100')), ether('0.1'));
+        const { r, vs } = compactSignature(signature);
+        await swap.connect(addr1).fillOrder(order, r, vs, makeMakingAmount(ether('100')), ether('0.1'));
 
         expect(await dai.balanceOf(addr.address)).to.equal(makerDaiBefore.sub(ether('100')));
         expect(await dai.balanceOf(addr1.address)).to.equal(takerDaiBefore.add(ether('100')));
@@ -95,7 +97,8 @@ describe('Dutch auction', function () {
     it('swap with takingAmount 0% time passed', async function () {
         const { dai, weth, swap, order, signature, makerDaiBefore, takerDaiBefore, makerWethBefore, takerWethBefore } = await loadFixture(deployAndBuildOrder);
 
-        await swap.connect(addr1).fillOrder(order, signature, '0x', ether('0.1'), ether('100'));
+        const { r, vs } = compactSignature(signature);
+        await swap.connect(addr1).fillOrder(order, r, vs, ether('0.1'), ether('100'));
 
         expect(await dai.balanceOf(addr.address)).to.equal(makerDaiBefore.sub(ether('100')));
         expect(await dai.balanceOf(addr1.address)).to.equal(takerDaiBefore.add(ether('100')));
@@ -107,7 +110,8 @@ describe('Dutch auction', function () {
         const { dai, weth, swap, ts, order, signature, makerDaiBefore, takerDaiBefore, makerWethBefore, takerWethBefore } = await loadFixture(deployAndBuildOrder);
 
         await time.increaseTo(ts + 86500n); // >100% auction time
-        await swap.connect(addr1).fillOrder(order, signature, '0x', makeMakingAmount(ether('100')), ether('0.05'));
+        const { r, vs } = compactSignature(signature);
+        await swap.connect(addr1).fillOrder(order, r, vs, makeMakingAmount(ether('100')), ether('0.05'));
 
         expect(await dai.balanceOf(addr.address)).to.equal(makerDaiBefore.sub(ether('100')));
         expect(await dai.balanceOf(addr1.address)).to.equal(takerDaiBefore.add(ether('100')));
@@ -119,7 +123,8 @@ describe('Dutch auction', function () {
         const { dai, weth, swap, ts, order, signature, makerDaiBefore, takerDaiBefore, makerWethBefore, takerWethBefore } = await loadFixture(deployAndBuildOrder);
 
         await time.increaseTo(ts + 86500n); // >100% auction time
-        await swap.connect(addr1).fillOrder(order, signature, '0x', ether('0.05'), ether('100'));
+        const { r, vs } = compactSignature(signature);
+        await swap.connect(addr1).fillOrder(order, r, vs, ether('0.05'), ether('100'));
 
         expect(await dai.balanceOf(addr.address)).to.equal(makerDaiBefore.sub(ether('100')));
         expect(await dai.balanceOf(addr1.address)).to.equal(takerDaiBefore.add(ether('100')));

--- a/test/helpers/orderUtils.js
+++ b/test/helpers/orderUtils.js
@@ -24,7 +24,6 @@ const Order = [
     { name: 'makingAmount', type: 'uint256' },
     { name: 'takingAmount', type: 'uint256' },
     { name: 'constraints', type: 'uint256' },
-    { name: 'maker', type: 'address' },
     { name: 'receiver', type: 'address' },
     { name: 'offsets', type: 'uint256' },
     { name: 'interactions', type: 'bytes' },
@@ -63,7 +62,6 @@ function buildOrder (
         takingAmount,
         constraints = '0',
         receiver = constants.ZERO_ADDRESS,
-        from: maker = constants.ZERO_ADDRESS,
     },
     {
         makerAssetData = '0x',
@@ -100,7 +98,6 @@ function buildOrder (
         salt: '1',
         makerAsset,
         takerAsset,
-        maker,
         receiver,
         constraints,
         makingAmount: makingAmount.toString(),


### PR DESCRIPTION
NGMI, but…

Running both gas reports with same compiler option `runs: 10_000`

Сheapest case with non-checking `ECRECOVER` on subsequent fills moved from `fillOrder` to `refillOrder` and became cheaper by 2300 gas:
```
·····························|··········|··········|··········|··········
|  Method                    ·  Min     ·  Max     ·  Avg     ·  calls  │
·····························|··········|··········|··········|··········
|  fillContractOrderRFQ      ·   78352  ·   95452  ·   86902  ·      2  │
·····························|··········|··········|··········|··········
|  fillOrder                 ·   81624  ·  133135  ·  107091  ·     39  │
·····························|··········|··········|··········|··········
|  fillOrderRFQ              ·   79988  ·  117408  ·  101042  ·      9  │
·····························|··········|··········|··········|··········
|  fillOrderRFQToWithPermit  ·  126003  ·  126029  ·  126016  ·      2  │
·····························|··········|··········|··········|··········
|  fillOrderToWithPermit     ·  133753  ·  133807  ·  133780  ·      2  │
·····························|··········|··········|··········|··········
```
=>
```
·····························|··········|··········|··········|··········
|  Method                    ·  Min     ·  Max     ·  Avg     ·  calls  │
·····························|··········|··········|··········|··········
|  fillContractOrderRFQ      ·   78410  ·   95510  ·   86960  ·      2  │
·····························|··········|··········|··········|··········
|  fillOrder                 ·   99519  ·  131696  ·  108396  ·     34  │
·····························|··········|··········|··········|··········
|  fillOrderRFQ              ·   80054  ·  117480  ·  101109  ·      9  │
·····························|··········|··········|··········|··········
|  fillOrderRFQToWithPermit  ·  126010  ·  126036  ·  126023  ·      2  │
·····························|··········|··········|··········|··········
|  fillOrderToWithPermit     ·  132885  ·  132936  ·  132911  ·      2  │
·····························|··········|··········|··········|··········
|  refillOrder               ·   79287  ·   90212  ·   87290  ·      5  │
·····························|··········|··········|··········|··········
```
