### PR TITLE
[SC-808] Measure gas diff for Limit orders V4 and V3

### DIFF
--- a/test/MeasureGas.js
+++ b/test/MeasureGas.js
@@ -1,0 +1,129 @@
+const hre = require('hardhat');
+const { ethers } = hre;
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { deploySwapTokens } = require('./helpers/fixtures');
+const { ether } = require('./helpers/utils');
+const { fillWithMakingAmount, signOrder, buildOrder, compactSignature, buildMakerTraits } = require('./helpers/orderUtils');
+
+describe('MeasureGas', function () {
+    before(async function () {
+        if (hre.__SOLIDITY_COVERAGE_RUNNING) { this.skip(); }
+    });
+
+    const initContracts = async function (addrs, dai, weth, swap) {
+        await dai.mint(addrs[1].address, ether('1000000'));
+        await dai.mint(addrs[0].address, ether('1000000'));
+        await weth.deposit({ value: ether('100') });
+        await weth.connect(addrs[1]).deposit({ value: ether('100') });
+        await dai.approve(swap.address, ether('1000000'));
+        await dai.connect(addrs[1]).approve(swap.address, ether('1000000'));
+        await weth.approve(swap.address, ether('100'));
+        await weth.connect(addrs[1]).approve(swap.address, ether('100'));
+    };
+
+    const deployContractsAndInit = async function () {
+        const addrs = await ethers.getSigners();
+        const { dai, weth, swap, chainId } = await deploySwapTokens();
+        await initContracts(addrs, dai, weth, swap);
+        return { addrs, dai, weth, swap, chainId };
+    };
+
+    it('swap without predicates', async function () {
+        const { addrs, dai, weth, swap, chainId } = await loadFixture(deployContractsAndInit);
+
+        const order = buildOrder({
+            makerAsset: dai.address,
+            takerAsset: weth.address,
+            makingAmount: 1,
+            takingAmount: 1,
+            maker: addrs[1].address,
+        });
+
+        const { r, vs } = compactSignature(await signOrder(order, chainId, swap.address, addrs[1]));
+        const tx = await swap.fillOrder(order, r, vs, 1, fillWithMakingAmount(1));
+        console.log(`swap without predicates gasUsed: ${(await tx.wait()).gasUsed}`);
+    });
+
+    it('swap partial fill without predicates', async function () {
+        const { addrs, dai, weth, swap, chainId } = await loadFixture(deployContractsAndInit);
+
+        const order = buildOrder({
+            makerAsset: dai.address,
+            takerAsset: weth.address,
+            makingAmount: 2,
+            takingAmount: 2,
+            maker: addrs[1].address,
+        });
+
+        const { r, vs } = compactSignature(await signOrder(order, chainId, swap.address, addrs[1]));
+        const tx = await swap.fillOrder(order, r, vs, 1, fillWithMakingAmount(1));
+        console.log(`swap partial fill without predicates gasUsed: ${(await tx.wait()).gasUsed}`);
+    });
+
+    it('swap with predicate nonce', async function () {
+        const { addrs, dai, weth, swap, chainId } = await loadFixture(deployContractsAndInit);
+
+        const order = buildOrder({
+            makerAsset: dai.address,
+            takerAsset: weth.address,
+            makingAmount: 1,
+            takingAmount: 1,
+            maker: addrs[1].address,
+            makerTraits: buildMakerTraits({ nonce: 1 }),
+        });
+
+        const { r, vs } = compactSignature(await signOrder(order, chainId, swap.address, addrs[1]));
+        const tx = await swap.fillOrder(order, r, vs, 1, fillWithMakingAmount(1));
+        console.log(`swap with predicate nonce gasUsed: ${(await tx.wait()).gasUsed}`);
+    });
+
+    it('swap with predicate expiry', async function () {
+        const { addrs, dai, weth, swap, chainId } = await loadFixture(deployContractsAndInit);
+
+        const order = buildOrder({
+            makerAsset: dai.address,
+            takerAsset: weth.address,
+            makingAmount: 1,
+            takingAmount: 1,
+            maker: addrs[1].address,
+            makerTraits: buildMakerTraits({ expiry: 0xff00000000 }),
+        });
+
+        const { r, vs } = compactSignature(await signOrder(order, chainId, swap.address, addrs[1]));
+        const tx = await swap.fillOrder(order, r, vs, 1, fillWithMakingAmount(1));
+        console.log(`swap with predicate expiry gasUsed: ${(await tx.wait()).gasUsed}`);
+    });
+
+    it('swap with predicate nonce and expiry', async function () {
+        const { addrs, dai, weth, swap, chainId } = await loadFixture(deployContractsAndInit);
+
+        const order = buildOrder({
+            makerAsset: dai.address,
+            takerAsset: weth.address,
+            makingAmount: 1,
+            takingAmount: 1,
+            maker: addrs[1].address,
+            makerTraits: buildMakerTraits({ nonce: 1, expiry: 0xff00000000 }),
+        });
+
+        const { r, vs } = compactSignature(await signOrder(order, chainId, swap.address, addrs[1]));
+        const tx = await swap.fillOrder(order, r, vs, 1, fillWithMakingAmount(1));
+        console.log(`swap with predicate nonce and expiry gasUsed: ${(await tx.wait()).gasUsed}`);
+    });
+
+    it('invalidate order', async function () {
+        const { addrs, dai, weth, swap } = await loadFixture(deployContractsAndInit);
+
+        const order = buildOrder({
+            makerAsset: dai.address,
+            takerAsset: weth.address,
+            makingAmount: 1,
+            takingAmount: 1,
+            maker: addrs[1].address,
+        });
+
+        const orderHash = await swap.hashOrder(order);
+        const tx = await swap.cancelOrder(order.makerTraits, orderHash); ;
+        console.log(`invalidate order gasUsed: ${(await tx.wait()).gasUsed}`);
+    });
+});


### PR DESCRIPTION
```
┌────────────────────────────┬──────────┬──────────┐
│        (index)             │  v4.0.0  │  v3.0.1  │
├────────────────────────────┴──────────┴──────────┤
│  Swaps without predicates                        │
├────────────────────────────┬──────────┬──────────┤
│ full fill                  │ '99228'  │ '107040' │
│ partial fill               │ '99216'  │ '107040' │
│ rfq fill                   │ '90333'  │ '91495'  │
├────────────────────────────┴──────────┴──────────┤
│  Swaps with predicates                           │
├────────────────────────────┬──────────┬──────────┤
│ `nonce`                    │ '99240'  │ '107040' │
│ `expiry`                   │ '99265'  │ '107040' │
│ `nonce` and `expiry`       │ '99277'  │ '113678' │
├────────────────────────────┴──────────┴──────────┤
│  Other                                           │
├────────────────────────────┬──────────┬──────────┤
│ Invalidate order           │ '44571'  │ '48809'  │
└────────────────────────────┴──────────┴──────────┘

Average method's values:
┌────────────────────────────┬─────────────────────┐
│        (index)             │  v4.0.0  │  v3.0.1  │
├────────────────────────────┼──────────┼──────────┤
│ fillContractOrder          │ '88241'  │ ---      │
│ fillContractOrderExt       │ '101474' │ ---      │
│ fillOrder                  │ '102692' │ '109585' │
│ fillOrderExt               │ '103931' │ ---      │
│ fillOrderToWithPermit      │ '131708' │ '135762' │
└────────────────────────────┴──────────┴──────────┘
```