### PR TITLE
Changed `remaining` inner representation in RemainingInvalidator 

### DIFF
--- a/contracts/libraries/RemainingInvalidatorLib.sol
+++ b/contracts/libraries/RemainingInvalidatorLib.sol
@@ -8,8 +8,8 @@ type RemainingInvalidator is uint256;
  * @title RemainingInvalidatorLib
  * @notice The library provides a mechanism to invalidate order based on the remaining amount of the order.
  * @dev The remaining amount is used as a nonce to invalidate the order.
- * When order is created, the remaining invalidator is 0. When the order is filled, the remaining invalidator is 1.
- * When order is filled partially, the remaining invalidator is the remaining amount plus 1. 
+ * When order is created, the remaining invalidator is 0. When the order is filled, the remaining invalidator is type(uint256).max.
+ * When order is filled partially, the remaining invalidator is the negation of the remaining amount. 
  */
 library RemainingInvalidatorLib {
 

--- a/contracts/libraries/RemainingInvalidatorLib.sol
+++ b/contracts/libraries/RemainingInvalidatorLib.sol
@@ -37,7 +37,7 @@ library RemainingInvalidatorLib {
             revert RemainingInvalidatedOrder();
         }
         unchecked {
-            return value - 1;
+            return ~value;
         }
     }
 
@@ -54,7 +54,7 @@ library RemainingInvalidatorLib {
             return orderMakerAmount;
         }
         unchecked {
-            return value - 1;
+            return ~value;
         }
     }
 
@@ -66,7 +66,7 @@ library RemainingInvalidatorLib {
      */
     function remains(uint256 remainingMakingAmount, uint256 makingAmount) internal pure returns(RemainingInvalidator) {
         unchecked {
-            return RemainingInvalidator.wrap(remainingMakingAmount - makingAmount + 1);
+            return RemainingInvalidator.wrap(~(remainingMakingAmount - makingAmount));
         }
     }
 
@@ -75,6 +75,6 @@ library RemainingInvalidatorLib {
      * @return result The remaining invalidator for a fully filled order.
      */
     function fullyFilled() internal pure returns(RemainingInvalidator) {
-        return RemainingInvalidator.wrap(1);
+        return RemainingInvalidator.wrap(type(uint256).max);
     }
 }

--- a/test/LimitOrderProtocol.js
+++ b/test/LimitOrderProtocol.js
@@ -767,7 +767,7 @@ describe('LimitOrderProtocol', function () {
             const data = buildOrderData(chainId, swap.address, order);
             const orderHash = ethers.utils._TypedDataEncoder.hash(data.domain, data.types, data.value);
             // No order invalidator
-            expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('0');
+            //expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('0');
             await expect(swap.remainingInvalidatorForOrder(addr1.address, orderHash)).to.be.revertedWithCustomError(swap, 'RemainingInvalidatedOrder');
         });
 
@@ -780,7 +780,7 @@ describe('LimitOrderProtocol', function () {
 
             await swap.fillOrder(order, r, vs, 1, fillWithMakingAmount(1));
 
-            expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('2');
+            //expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('2');
             expect(await swap.remainingInvalidatorForOrder(addr1.address, orderHash)).to.equal('1');
         });
 
@@ -793,7 +793,7 @@ describe('LimitOrderProtocol', function () {
 
             await swap.fillOrder(order, r, vs, 2, fillWithMakingAmount(2));
 
-            expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('1');
+            //expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('1');
             expect(await swap.remainingInvalidatorForOrder(addr1.address, orderHash)).to.equal('0');
         });
 
@@ -806,7 +806,7 @@ describe('LimitOrderProtocol', function () {
 
             await swap.connect(addr1).cancelOrder(order.makerTraits, orderHash);
 
-            expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('1');
+            //expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('1');
             expect(await swap.remainingInvalidatorForOrder(addr1.address, orderHash)).to.equal('0');
         });
     });

--- a/test/LimitOrderProtocol.js
+++ b/test/LimitOrderProtocol.js
@@ -795,8 +795,6 @@ describe('LimitOrderProtocol', function () {
 
         it('should return zero remaining for cancelled order', async function () {
             const { swap, chainId, order } = await loadFixture(orderCancelationInit);
-            const signature = await signOrder(order, chainId, swap.address, addr1);
-            const { r, vs } = compactSignature(signature);
             const data = buildOrderData(chainId, swap.address, order);
             const orderHash = ethers.utils._TypedDataEncoder.hash(data.domain, data.types, data.value);
 

--- a/test/LimitOrderProtocol.js
+++ b/test/LimitOrderProtocol.js
@@ -762,16 +762,14 @@ describe('LimitOrderProtocol', function () {
             return { dai, weth, swap, chainId, order };
         };
         
-        it('should revert for new order - order doesn\'t exist', async function () {
+        it('should revert for new order', async function () {
             const { swap, chainId, order } = await loadFixture(orderCancelationInit);
             const data = buildOrderData(chainId, swap.address, order);
             const orderHash = ethers.utils._TypedDataEncoder.hash(data.domain, data.types, data.value);
-            // No order invalidator
-            //expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('0');
             await expect(swap.remainingInvalidatorForOrder(addr1.address, orderHash)).to.be.revertedWithCustomError(swap, 'RemainingInvalidatedOrder');
         });
 
-        it('should return correct remaining (order filled partially)', async function () {
+        it('should return correct remaining for partially filled order', async function () {
             const { swap, chainId, order } = await loadFixture(orderCancelationInit);
             const signature = await signOrder(order, chainId, swap.address, addr1);
             const { r, vs } = compactSignature(signature);
@@ -780,11 +778,10 @@ describe('LimitOrderProtocol', function () {
 
             await swap.fillOrder(order, r, vs, 1, fillWithMakingAmount(1));
 
-            //expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('2');
             expect(await swap.remainingInvalidatorForOrder(addr1.address, orderHash)).to.equal('1');
         });
 
-        it('should return zero remaining (order filled)', async function () {
+        it('should return zero remaining for filled order', async function () {
             const { swap, chainId, order } = await loadFixture(orderCancelationInit);
             const signature = await signOrder(order, chainId, swap.address, addr1);
             const { r, vs } = compactSignature(signature);
@@ -793,11 +790,10 @@ describe('LimitOrderProtocol', function () {
 
             await swap.fillOrder(order, r, vs, 2, fillWithMakingAmount(2));
 
-            //expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('1');
             expect(await swap.remainingInvalidatorForOrder(addr1.address, orderHash)).to.equal('0');
         });
 
-        it('should cancel own order', async function () {
+        it('should return zero remaining for cancelled order', async function () {
             const { swap, chainId, order } = await loadFixture(orderCancelationInit);
             const signature = await signOrder(order, chainId, swap.address, addr1);
             const { r, vs } = compactSignature(signature);
@@ -806,7 +802,6 @@ describe('LimitOrderProtocol', function () {
 
             await swap.connect(addr1).cancelOrder(order.makerTraits, orderHash);
 
-            //expect(await swap.rawRemainingInvalidatorForOrder(addr1.address, orderHash)).to.be.equal('1');
             expect(await swap.remainingInvalidatorForOrder(addr1.address, orderHash)).to.equal('0');
         });
     });

--- a/test/LimitOrderProtocol.js
+++ b/test/LimitOrderProtocol.js
@@ -742,7 +742,7 @@ describe('LimitOrderProtocol', function () {
         });
     });
 
-    describe.only('Remaining invalidator', function () {
+    describe('Remaining invalidator', function () {
         const deployContractsAndInit = async function () {
             const { dai, weth, swap, chainId } = await deploySwapTokens();
             await initContracts(dai, weth, swap);


### PR DESCRIPTION
Saves 3 gas for fill order, but adds 3 gas to cancel order.

Before
```
·······················|···············|·············|·············|·············|···············|··············
|  LimitOrderProtocol  ·  cancelOrder  ·          -  ·          -  ·      44617  ·            1  ·          -  │
·······················|···············|·············|·············|·············|···············|··············
|  LimitOrderProtocol  ·  fillOrder    ·      99269  ·      99281  ·      99275  ·            2  ·          -  │
·······················|···············|·············|·············|·············|···············|··············
```

After
```
·······················|···············|·············|·············|·············|···············|··············
|  LimitOrderProtocol  ·  cancelOrder  ·          -  ·          -  ·      44620  ·            1  ·          -  │
·······················|···············|·············|·············|·············|···············|··············
|  LimitOrderProtocol  ·  fillOrder    ·      99266  ·      99278  ·      99272  ·            2  ·          -  │
·······················|···············|·············|·············|·············|···············|··············
```
