### PR TITLE
[SC-1198] Upgrade FeeTaker

### DIFF
--- a/contracts/extensions/AmountGetterBase.sol
+++ b/contracts/extensions/AmountGetterBase.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { IAmountGetter } from "../interfaces/IAmountGetter.sol";
+import { IOrderMixin } from "../interfaces/IOrderMixin.sol";
+
+/// @title Base price getter contract that either calls external getter or applies linear formula
+contract AmountGetterBase is IAmountGetter {
+    function getMakingAmount(
+        IOrderMixin.Order calldata order,
+        bytes calldata extension,
+        bytes32 orderHash,
+        address taker,
+        uint256 takingAmount,
+        uint256 remainingMakingAmount,
+        bytes calldata extraData
+    ) external view returns (uint256) {
+        return _getMakingAmount(order, extension, orderHash, taker, takingAmount, remainingMakingAmount, extraData);
+    }
+
+    function getTakingAmount(
+        IOrderMixin.Order calldata order,
+        bytes calldata extension,
+        bytes32 orderHash,
+        address taker,
+        uint256 makingAmount,
+        uint256 remainingMakingAmount,
+        bytes calldata extraData
+    ) external view returns (uint256) {
+        return _getTakingAmount(order, extension, orderHash, taker, makingAmount, remainingMakingAmount, extraData);
+    }
+
+    function _getMakingAmount(
+        IOrderMixin.Order calldata order,
+        bytes calldata extension,
+        bytes32 orderHash,
+        address taker,
+        uint256 takingAmount,
+        uint256 remainingMakingAmount,
+        bytes calldata extraData
+    ) internal view virtual returns (uint256) {
+        if (extraData.length >= 20) {
+            return IAmountGetter(address(bytes20(extraData))).getMakingAmount(
+                order, extension, orderHash, taker, takingAmount, remainingMakingAmount, extraData[20:]
+            );
+        } else {
+            return Math.mulDiv(order.makingAmount, takingAmount, order.takingAmount);
+        }
+    }
+
+    function _getTakingAmount(
+        IOrderMixin.Order calldata order,
+        bytes calldata extension,
+        bytes32 orderHash,
+        address taker,
+        uint256 makingAmount,
+        uint256 remainingMakingAmount,
+        bytes calldata extraData
+    ) internal view virtual returns (uint256) {
+        if (extraData.length >= 20) {
+            return IAmountGetter(address(bytes20(extraData))).getTakingAmount(
+                order, extension, orderHash, taker, makingAmount, remainingMakingAmount, extraData[20:]
+            );
+        } else {
+            return Math.mulDiv(order.takingAmount, makingAmount, order.makingAmount, Math.Rounding.Ceil);
+        }
+    }
+}

--- a/contracts/extensions/AmountGetterWithFee.sol
+++ b/contracts/extensions/AmountGetterWithFee.sol
@@ -88,7 +88,7 @@ contract AmountGetterWithFee is AmountGetterBase {
      * @param whitelistData Whitelist data is a tightly packed struct of the following format:
      * ```
      * 1 byte - size of the whitelist
-     * (bytes10)[N] whiteliested addresses;
+     * (bytes10)[N] whitelisted addresses;
      * ```
      * Only 10 lowest bytes of the address are used for comparison.
      * @param taker The taker address to check.

--- a/contracts/extensions/AmountGetterWithFee.sol
+++ b/contracts/extensions/AmountGetterWithFee.sol
@@ -24,7 +24,7 @@ contract AmountGetterWithFee is AmountGetterBase {
         uint256 takingAmount,
         uint256 remainingMakingAmount,
         bytes calldata extraData
-    ) internal view override returns (uint256) {
+    ) internal view virtual override returns (uint256) {
         unchecked {
             (, uint256 integratorFee, uint256 resolverFee, bytes calldata tail) = _parseFeeData(extraData, taker, _isWhitelistedGetterImpl);
             return Math.mulDiv(
@@ -46,7 +46,7 @@ contract AmountGetterWithFee is AmountGetterBase {
         uint256 makingAmount,
         uint256 remainingMakingAmount,
         bytes calldata extraData
-    ) internal view override returns (uint256) {
+    ) internal view virtual override returns (uint256) {
         unchecked {
             (, uint256 integratorFee, uint256 resolverFee, bytes calldata tail) = _parseFeeData(extraData, taker, _isWhitelistedGetterImpl);
             return Math.mulDiv(

--- a/contracts/extensions/AmountGetterWithFee.sol
+++ b/contracts/extensions/AmountGetterWithFee.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.23;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { IOrderMixin } from "../interfaces/IOrderMixin.sol";
+import { AmountGetterBase } from "./AmountGetterBase.sol";
+
+/// @title Price getter contract that adds fee calculation
+contract AmountGetterWithFee is AmountGetterBase {
+    /// @dev Allows fees in range [1e-5, 0.65535]
+    uint256 internal constant _FEE_BASE = 1e5;
+    uint256 internal constant _DISCOUNT_BASE = 100;
+
+    /**
+     * @dev Calculates makingAmount with fee.
+     */
+    function _getMakingAmount(
+        IOrderMixin.Order calldata order,
+        bytes calldata extension,
+        bytes32 orderHash,
+        address taker,
+        uint256 takingAmount,
+        uint256 remainingMakingAmount,
+        bytes calldata extraData
+    ) internal view override returns (uint256) {
+        unchecked {
+            (, uint256 integratorFee, uint256 resolverFee, bytes calldata tail) = _parseFeeData(extraData, taker, _isWhitelistedGetterImpl);
+            return Math.mulDiv(
+                super._getMakingAmount(order, extension, orderHash, taker, takingAmount, remainingMakingAmount, tail),
+                _FEE_BASE,
+                _FEE_BASE + integratorFee + resolverFee
+            );
+        }
+    }
+
+    /**
+     * @dev Calculates takingAmount with fee.
+     */
+    function _getTakingAmount(
+        IOrderMixin.Order calldata order,
+        bytes calldata extension,
+        bytes32 orderHash,
+        address taker,
+        uint256 makingAmount,
+        uint256 remainingMakingAmount,
+        bytes calldata extraData
+    ) internal view override returns (uint256) {
+        unchecked {
+            (, uint256 integratorFee, uint256 resolverFee, bytes calldata tail) = _parseFeeData(extraData, taker, _isWhitelistedGetterImpl);
+            return Math.mulDiv(
+                super._getTakingAmount(order, extension, orderHash, taker, makingAmount, remainingMakingAmount, tail),
+                _FEE_BASE + integratorFee + resolverFee,
+                _FEE_BASE,
+                Math.Rounding.Ceil
+            );
+        }
+    }
+
+    /**
+     * @dev `extraData` consists of:
+     * 2 bytes — integrator fee percentage (in 1e5)
+     * 2 bytes — resolver fee percentage (in 1e5)
+     * 1 byte - whitelist discount numerator (in 1e2)
+     * bytes — whitelist structure determined by `_isWhitelisted` implementation
+     * bytes — custom data (optional)
+     * @param _isWhitelisted internal function to parse and check whitelist
+     */
+    function _parseFeeData(
+        bytes calldata extraData,
+        address taker,
+        function (bytes calldata, address) internal view returns (bool, bytes calldata) _isWhitelisted
+    ) internal view returns (bool isWhitelisted, uint256 integratorFee, uint256 resolverFee, bytes calldata tail) {
+        unchecked {
+            integratorFee = uint256(uint16(bytes2(extraData)));
+            resolverFee = uint256(uint16(bytes2(extraData[2:])));
+            uint256 whitelistDiscountNumerator = uint256(uint8(bytes1(extraData[4:])));
+            (isWhitelisted, tail) = _isWhitelisted(extraData[5:], taker);
+            if (isWhitelisted) {
+                resolverFee = resolverFee * whitelistDiscountNumerator / _DISCOUNT_BASE;
+            }
+        }
+    }
+
+    /**
+     * @dev Validates whether the taker is whitelisted.
+     * @param whitelistData Whitelist data is a tightly packed struct of the following format:
+     * ```
+     * 1 byte - size of the whitelist
+     * (bytes10)[N] whiteliested addresses;
+     * ```
+     * Only 10 lowest bytes of the address are used for comparison.
+     * @param taker The taker address to check.
+     * @return isWhitelisted Whether the taker is whitelisted.
+     * @return tail Remaining calldata.
+     */
+    function _isWhitelistedGetterImpl(bytes calldata whitelistData, address taker) internal pure returns (bool isWhitelisted, bytes calldata tail) {
+        unchecked {
+            uint80 maskedTakerAddress = uint80(uint160(taker));
+            uint256 size = uint8(whitelistData[0]);
+            bytes calldata whitelist = whitelistData[1:1 + 10 * size];
+            tail = whitelistData[1 + 10 * size:];
+            for (uint256 i = 0; i < size; i++) {
+                uint80 whitelistedAddress = uint80(bytes10(whitelist[:10]));
+                if (maskedTakerAddress == whitelistedAddress) {
+                    return (true, tail);
+                }
+                whitelist = whitelist[10:];
+            }
+        }
+    }
+}

--- a/contracts/extensions/FeeTaker.sol
+++ b/contracts/extensions/FeeTaker.sol
@@ -38,6 +38,11 @@ contract FeeTaker is IPostInteraction, AmountGetterWithFee, Ownable {
      */
     error EthTransferFailed();
 
+    /**
+      * @dev Fees are specified but FeeTaker is not set as a receiver.
+      */
+    error InconsistentFee();
+
     address private immutable _LIMIT_ORDER_PROTOCOL;
     address private immutable _WETH;
     /// @notice Contract address whose tokens allow filling limit orders with a fee for resolvers that are outside the whitelist
@@ -140,6 +145,8 @@ contract FeeTaker is IPostInteraction, AmountGetterWithFee, Ownable {
                     }
                     IERC20(order.takerAsset.get()).safeTransfer(receiver, takingAmount - fee);
                 }
+            } else if (fee > 0) {
+                revert InconsistentFee();
             }
 
             if (tail.length >= 20) {

--- a/contracts/extensions/FeeTaker.sol
+++ b/contracts/extensions/FeeTaker.sol
@@ -38,11 +38,6 @@ contract FeeTaker is IPostInteraction, AmountGetterWithFee, Ownable {
      */
     error EthTransferFailed();
 
-    /**
-     * @dev Fee taker is set to be receiver but no fees were set.
-     */
-    error InconsistentFee();
-
     address private immutable _LIMIT_ORDER_PROTOCOL;
     address private immutable _WETH;
     /// @notice Contract address whose tokens allow filling limit orders with a fee for resolvers that are outside the whitelist

--- a/contracts/extensions/FeeTaker.sol
+++ b/contracts/extensions/FeeTaker.sol
@@ -72,6 +72,9 @@ contract FeeTaker is IPostInteraction, AmountGetterWithFee, Ownable {
      */
     receive() external payable {}
 
+    /**
+     * @notice See {IPostInteraction-postInteraction}.
+     */
     function postInteraction(
         IOrderMixin.Order calldata order,
         bytes calldata extension,

--- a/contracts/extensions/FeeTaker.sol
+++ b/contracts/extensions/FeeTaker.sol
@@ -134,8 +134,6 @@ contract FeeTaker is IPostInteraction, AmountGetterWithFee, Ownable {
             uint256 fee = Math.mulDiv(takingAmount, integratorFee, denominator) + Math.mulDiv(takingAmount, resolverFee, denominator);
 
             if (order.receiver.get() == address(this)) {
-                if (integratorFee + resolverFee == 0) revert InconsistentFee();
-
                 if (order.takerAsset.get() == address(_WETH) && order.makerTraits.unwrapWeth()) {
                     if (fee > 0) {
                         _sendEth(feeRecipient, fee);

--- a/contracts/extensions/FeeTaker.sol
+++ b/contracts/extensions/FeeTaker.sol
@@ -134,7 +134,7 @@ contract FeeTaker is IPostInteraction, AmountGetterWithFee, Ownable {
             uint256 fee = Math.mulDiv(takingAmount, integratorFee, denominator) + Math.mulDiv(takingAmount, resolverFee, denominator);
 
             if (order.receiver.get() == address(this)) {
-                if (fee == 0) revert InconsistentFee();
+                if (integratorFee + resolverFee == 0) revert InconsistentFee();
 
                 if (order.takerAsset.get() == address(_WETH) && order.makerTraits.unwrapWeth()) {
                     if (fee > 0) {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,7 @@
   },
   "license": "MIT",
   "files": [
-    "contracts/*.sol",
-    "contracts/helpers",
-    "contracts/interfaces",
-    "contracts/libraries",
-    "contracts/mocks",
+    "contracts",
     "test/helpers"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/limit-order-protocol-contract",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "1inch Limit Order Protocol",
   "repository": {
     "type": "git",

--- a/test/FeeTaker.js
+++ b/test/FeeTaker.js
@@ -45,16 +45,12 @@ describe('FeeTaker', function () {
         const order = buildOrder(
             {
                 maker: addr1.address,
-                receiver: await feeTaker.getAddress(),
                 makerAsset: await dai.getAddress(),
                 takerAsset: await weth.getAddress(),
                 makingAmount,
                 takingAmount,
             },
-            buildFeeTakerExtensions({
-                feeTaker: await feeTaker.getAddress(),
-                feeRecipient,
-            }),
+            buildFeeTakerExtensions({ feeTaker: await feeTaker.getAddress() }),
         );
 
         const { r, yParityAndS: vs } = ethers.Signature.from(await signOrder(order, chainId, await swap.getAddress(), addr1));
@@ -78,17 +74,13 @@ describe('FeeTaker', function () {
         const order = buildOrder(
             {
                 maker: addr1.address,
-                receiver: await feeTaker.getAddress(),
+                receiver: makerReceiver,
                 makerAsset: await dai.getAddress(),
                 takerAsset: await weth.getAddress(),
                 makingAmount,
                 takingAmount,
             },
-            buildFeeTakerExtensions({
-                feeTaker: await feeTaker.getAddress(),
-                feeRecipient,
-                makerReceiver,
-            }),
+            buildFeeTakerExtensions({ feeTaker: await feeTaker.getAddress() }),
         );
 
         const { r, yParityAndS: vs } = ethers.Signature.from(await signOrder(order, chainId, await swap.getAddress(), addr1));

--- a/test/FeeTaker.js
+++ b/test/FeeTaker.js
@@ -6,7 +6,7 @@ const { deploySwapTokens } = require('./helpers/fixtures');
 const { buildOrder, buildTakerTraits, signOrder, buildMakerTraits, buildFeeTakerExtensions } = require('./helpers/orderUtils');
 const { ether } = require('./helpers/utils');
 
-describe.only('FeeTaker', function () {
+describe('FeeTaker', function () {
     let addr, addr1, addr2, addr3;
     before(async function () {
         [addr, addr1, addr2, addr3] = await ethers.getSigners();
@@ -109,7 +109,7 @@ describe.only('FeeTaker', function () {
         const integratorFee = BigInt(1e4);
         const resolverFee = BigInt(1e3);
         const feeRecipient = addr2.address;
-        const whitelist = '0x' + addr.address.slice(-20).repeat(10);
+        const whitelist = '0x0a' + addr.address.slice(-20).repeat(10);
 
         const order = buildOrder(
             {
@@ -125,7 +125,6 @@ describe.only('FeeTaker', function () {
                 feeRecipient,
                 integratorFee,
                 resolverFee,
-                whitelistLength: 10,
                 whitelist,
             }),
         );
@@ -151,7 +150,7 @@ describe.only('FeeTaker', function () {
         const integratorFee = BigInt(1e4);
         const resolverFee = BigInt(1e3);
         const feeRecipient = addr2.address;
-        const whitelist = '0x' + addr2.address.slice(-20).repeat(10);
+        const whitelist = '0x0a' + addr2.address.slice(-20).repeat(10);
 
         const order = buildOrder(
             {
@@ -167,7 +166,6 @@ describe.only('FeeTaker', function () {
                 feeRecipient,
                 integratorFee,
                 resolverFee,
-                whitelistLength: 10,
                 whitelist,
             }),
         );

--- a/test/FeeTaker.js
+++ b/test/FeeTaker.js
@@ -64,7 +64,7 @@ describe.only('FeeTaker', function () {
         const fillTx = swap.fillOrderArgs(order, r, vs, makingAmount, takerTraits.traits, takerTraits.args);
         console.log(`GasUsed: ${(await (await fillTx).wait()).gasUsed.toString()}`);
         await expect(fillTx).to.changeTokenBalances(dai, [addr, addr1], [makingAmount, -makingAmount]);
-        await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1, addr2], [-takingAmount, takingAmount, 0]);
+        await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1, feeRecipient], [-takingAmount, takingAmount, 0]);
     });
 
     it('should send all tokens to the maker receiver with 0 fee', async function () {
@@ -98,7 +98,7 @@ describe.only('FeeTaker', function () {
         const fillTx = swap.fillOrderArgs(order, r, vs, makingAmount, takerTraits.traits, takerTraits.args);
         console.log(`GasUsed: ${(await (await fillTx).wait()).gasUsed.toString()}`);
         await expect(fillTx).to.changeTokenBalances(dai, [addr, addr1], [makingAmount, -makingAmount]);
-        await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1, addr2, addr3], [-takingAmount, 0, 0, takingAmount]);
+        await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1, feeRecipient, makerReceiver], [-takingAmount, 0, 0, takingAmount]);
     });
 
     it('should charge fee when in whitelist', async function () {
@@ -140,7 +140,7 @@ describe.only('FeeTaker', function () {
 
         const feeCalculated = takingAmount * (integratorFee + resolverFee / 2n) / BigInt(1e5);
         await expect(fillTx).to.changeTokenBalances(dai, [addr, addr1], [makingAmount, -makingAmount]);
-        await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1, addr2], [-takingAmount - feeCalculated, takingAmount, feeCalculated]);
+        await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1, feeRecipient], [-takingAmount - feeCalculated, takingAmount, feeCalculated]);
     });
 
     it('should charge fee when out of whitelist', async function () {
@@ -183,7 +183,7 @@ describe.only('FeeTaker', function () {
         const feeCalculated = takingAmount * (integratorFee + resolverFee) / BigInt(1e5);
         await expect(fillTx).to.changeTokenBalances(dai, [addr, addr1], [makingAmount, -makingAmount]);
         await expect(fillTx).to.changeTokenBalances(weth,
-            [addr, addr1, addr2],
+            [addr, addr1, feeRecipient],
             [-takingAmount - feeCalculated, takingAmount, feeCalculated],
         );
     });
@@ -222,7 +222,7 @@ describe.only('FeeTaker', function () {
         const fillTx = swap.fillOrderArgs(order, r, vs, makingAmount, takerTraits.traits, takerTraits.args);
         console.log(`GasUsed: ${(await (await fillTx).wait()).gasUsed.toString()}`);
         await expect(fillTx).to.changeTokenBalances(dai, [addr, addr1], [makingAmount, -makingAmount]);
-        await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1, addr2, addr3], [-takingAmount - feeCalculated, 0, feeCalculated, takingAmount]);
+        await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1, feeRecipient, makerReceiver], [-takingAmount - feeCalculated, 0, feeCalculated, takingAmount]);
     });
 
     it('should charge fee in eth', async function () {
@@ -259,7 +259,7 @@ describe.only('FeeTaker', function () {
         console.log(`GasUsed: ${(await (await fillTx).wait()).gasUsed.toString()}`);
         await expect(fillTx).to.changeTokenBalances(dai, [addr, addr1], [makingAmount, -makingAmount]);
         await expect(fillTx).to.changeTokenBalance(weth, addr, -takingAmount - feeCalculated);
-        await expect(fillTx).to.changeEtherBalances([addr1, addr2], [takingAmount, feeCalculated]);
+        await expect(fillTx).to.changeEtherBalances([addr1, feeRecipient], [takingAmount, feeCalculated]);
     });
 
     it('should charge fee in eth and send the rest to the maker receiver', async function () {
@@ -298,6 +298,6 @@ describe.only('FeeTaker', function () {
         console.log(`GasUsed: ${(await (await fillTx).wait()).gasUsed.toString()}`);
         await expect(fillTx).to.changeTokenBalances(dai, [addr, addr1], [makingAmount, -makingAmount]);
         await expect(fillTx).to.changeTokenBalance(weth, addr, -takingAmount - feeCalculated);
-        await expect(fillTx).to.changeEtherBalances([addr1, addr2, addr3], [0, feeCalculated, takingAmount]);
+        await expect(fillTx).to.changeEtherBalances([addr1, feeRecipient, makerReceiver], [0, feeCalculated, takingAmount]);
     });
 });

--- a/test/helpers/orderUtils.js
+++ b/test/helpers/orderUtils.js
@@ -124,6 +124,39 @@ function buildMakerTraits ({
     ).toString(16).padStart(64, '0');
 }
 
+function buildFeeTakerExtensions({
+    feeTaker,
+    feeRecipient,
+    makerReceiver = undefined,
+    integratorFee = 0,
+    resolverFee = 0,
+    whitelistDiscount = 50,
+    whitelistLength = 0,
+    whitelist = '0x',
+    whitelistPostInteraction = whitelist,
+}) {
+    return {
+        makingAmountData: ethers.solidityPacked(
+            ['address', 'uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
+            [feeTaker, integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelist],
+        ),
+        takingAmountData: ethers.solidityPacked(
+            ['address', 'uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
+            [feeTaker, integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelist],
+        ),
+        postInteraction: ethers.solidityPacked(
+            ['address', 'bytes1', 'address'].concat(
+                makerReceiver ? ['address'] : [],
+                ['uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
+            ),
+            [feeTaker, makerReceiver ? '0x01' : '0x00', feeRecipient].concat(
+                makerReceiver ? [makerReceiver] : [],
+                [integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelistPostInteraction],
+            ),
+        ),
+    }
+}
+
 function buildOrderRFQ (
     {
         maker,
@@ -276,6 +309,7 @@ module.exports = {
     buildTakerTraits,
     buildMakerTraits,
     buildMakerTraitsRFQ,
+    buildFeeTakerExtensions,
     buildOrder,
     buildOrderRFQ,
     buildOrderData,

--- a/test/helpers/orderUtils.js
+++ b/test/helpers/orderUtils.js
@@ -124,7 +124,7 @@ function buildMakerTraits ({
     ).toString(16).padStart(64, '0');
 }
 
-function buildFeeTakerExtensions({
+function buildFeeTakerExtensions ({
     feeTaker,
     feeRecipient,
     makerReceiver = undefined,
@@ -154,7 +154,7 @@ function buildFeeTakerExtensions({
                 [integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelistPostInteraction],
             ),
         ),
-    }
+    };
 }
 
 function buildOrderRFQ (

--- a/test/helpers/orderUtils.js
+++ b/test/helpers/orderUtils.js
@@ -134,24 +134,27 @@ function buildFeeTakerExtensions ({
     whitelistDiscount = 50,
     whitelist = '0x00',
     whitelistPostInteraction = whitelist,
+    customMakingGetter = '0x',
+    customTakingGetter = '0x',
+    customPostInteraction = '0x',
 }) {
     return {
         makingAmountData: ethers.solidityPacked(
-            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'bytes'],
-            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelist],
+            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'bytes', 'bytes'],
+            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelist, customMakingGetter],
         ),
         takingAmountData: ethers.solidityPacked(
-            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'bytes'],
-            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelist],
+            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'bytes', 'bytes'],
+            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelist, customTakingGetter],
         ),
         postInteraction: ethers.solidityPacked(
             ['address', 'bytes1', 'address'].concat(
                 makerReceiver ? ['address'] : [],
-                ['uint16', 'uint16', 'uint8', 'bytes'],
+                ['uint16', 'uint16', 'uint8', 'bytes', 'bytes'],
             ),
             [feeTaker, makerReceiver ? '0x01' : '0x00', feeRecipient].concat(
                 makerReceiver ? [makerReceiver] : [],
-                [integratorFee, resolverFee, whitelistDiscount, whitelistPostInteraction],
+                [integratorFee, resolverFee, whitelistDiscount, whitelistPostInteraction, customPostInteraction],
             ),
         ),
     };

--- a/test/helpers/orderUtils.js
+++ b/test/helpers/orderUtils.js
@@ -126,6 +126,7 @@ function buildMakerTraits ({
 
 function buildFeeTakerExtensions ({
     feeTaker,
+    getterExtraPrefix = '0x',
     feeRecipient,
     makerReceiver = undefined,
     integratorFee = 0,
@@ -137,12 +138,12 @@ function buildFeeTakerExtensions ({
 }) {
     return {
         makingAmountData: ethers.solidityPacked(
-            ['address', 'uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
-            [feeTaker, integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelist],
+            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
+            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelist],
         ),
         takingAmountData: ethers.solidityPacked(
-            ['address', 'uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
-            [feeTaker, integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelist],
+            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
+            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelist],
         ),
         postInteraction: ethers.solidityPacked(
             ['address', 'bytes1', 'address'].concat(

--- a/test/helpers/orderUtils.js
+++ b/test/helpers/orderUtils.js
@@ -127,7 +127,7 @@ function buildMakerTraits ({
 function buildFeeTakerExtensions ({
     feeTaker,
     getterExtraPrefix = '0x',
-    feeRecipient,
+    feeRecipient = constants.ZERO_ADDRESS,
     makerReceiver = undefined,
     integratorFee = 0,
     resolverFee = 0,

--- a/test/helpers/orderUtils.js
+++ b/test/helpers/orderUtils.js
@@ -132,27 +132,26 @@ function buildFeeTakerExtensions ({
     integratorFee = 0,
     resolverFee = 0,
     whitelistDiscount = 50,
-    whitelistLength = 0,
-    whitelist = '0x',
+    whitelist = '0x00',
     whitelistPostInteraction = whitelist,
 }) {
     return {
         makingAmountData: ethers.solidityPacked(
-            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
-            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelist],
+            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'bytes'],
+            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelist],
         ),
         takingAmountData: ethers.solidityPacked(
-            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
-            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelist],
+            ['address', 'bytes', 'uint16', 'uint16', 'uint8', 'bytes'],
+            [feeTaker, getterExtraPrefix, integratorFee, resolverFee, whitelistDiscount, whitelist],
         ),
         postInteraction: ethers.solidityPacked(
             ['address', 'bytes1', 'address'].concat(
                 makerReceiver ? ['address'] : [],
-                ['uint16', 'uint16', 'uint8', 'uint8', 'bytes'],
+                ['uint16', 'uint16', 'uint8', 'bytes'],
             ),
             [feeTaker, makerReceiver ? '0x01' : '0x00', feeRecipient].concat(
                 makerReceiver ? [makerReceiver] : [],
-                [integratorFee, resolverFee, whitelistDiscount, whitelistLength, whitelistPostInteraction],
+                [integratorFee, resolverFee, whitelistDiscount, whitelistPostInteraction],
             ),
         ),
     };


### PR DESCRIPTION
- Getters are split to multiple classes. The idea is that each new getter calls super and adds some extra multiplication overhead
- `FeeTaker` checks that taker is either in whitelist or has `AccessToken`
- `_parseFeeData` is universal for getters and postInteraction
- `_isWhitelisted` is virtual to allow for different whitelist structure in getters and postInteraction
- `postInteraction` now allows custom chained calls to other post-interactions