### PR TITLE
[SC-1387] Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/limit-order-protocol-contract",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "1inch Limit Order Protocol",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump version after audit fixes: https://github.com/1inch/limit-order-protocol/pull/347, https://github.com/1inch/limit-order-protocol/pull/348 and https://github.com/1inch/limit-order-protocol/pull/350/