### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **1inch Limit Order Protocol** — EVM Solidity smart contracts built with
+Hardhat. There is no long-running server or web app; "running the application" means
+compiling contracts, running the test suite, and optionally spinning up a local Hardhat
+blockchain to deploy/fill orders. The package manager is **yarn** (see `yarn.lock`).
+Standard commands live in `package.json` `scripts` and the `Makefile`; prefer those.
+
+Common commands:
+- Compile: `yarn hardhat compile`
+- Lint (ESLint + solhint): `yarn lint`
+- Tests (full, reliable run): `yarn test:ci`
+- Local blockchain: `yarn hardhat node`, then run scripts with `--network localhost`
+- Coverage: `yarn coverage`
+
+Non-obvious gotchas (durable):
+- **Use `yarn test:ci`, not `yarn test`, for a full green run.** `yarn test` passes
+  `--parallel`, which disables `hardhat-tracer` (and the gas reporter). Two tracer-based
+  `wip` tests in `test/LimitOrderProtocol.js` (`should swap fully/half based on signature`)
+  then fail with `Cannot read properties of undefined (reading 'top')`. They pass under the
+  non-parallel `yarn test:ci`, which is what CI runs.
+- The `Network '<name>' not registered` lines printed during `compile`/`run` are expected
+  when no RPC/`.env` config is present. They are harmless for local development and testing.
+- `yarn lint` currently fails on a pre-existing issue on `master`:
+  `deploy/deploy-Permit2Proxy.js` uses `getNamedAccounts` without importing it from `hre`
+  (`no-undef`). This is a repo code issue, not an environment problem; the lint tooling
+  itself works.
+- Node: CI uses Node 20; Node 22 also works for compile/test/run in this environment.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates a full development environment for the 1inch Limit Order Protocol (Hardhat/Solidity) and documents non-obvious setup gotchas for future cloud agents.

This PR adds a single file, `AGENTS.md`, with a `## Cursor Cloud specific instructions` section. No application code was modified.

## What was validated

- Install: `yarn install --frozen-lockfile`
- Compile: `yarn hardhat compile` — 127 Solidity files compiled (solc 0.8.30, viaIR).
- Lint: `yarn lint` — tooling works; surfaces a **pre-existing** `no-undef` on `deploy/deploy-Permit2Proxy.js` (`getNamedAccounts` used without import). Not an environment issue.
- Tests: `yarn test:ci` — **173 passing, 5 pending**. Note: `yarn test` (parallel) breaks 2 tracer-based `wip` tests because `--parallel` disables `hardhat-tracer`; `yarn test:ci` is the reliable full run (and what CI uses).

## Hello-world (end-to-end)

Started a local Hardhat node (`yarn hardhat node`) and ran a throwaway script that deployed `LimitOrderProtocol` + mock tokens, had a maker sign an EIP-712 limit order (100 DAI → 0.1 WETH), and a taker fill it on-chain. Balances moved correctly (taker +100 DAI, maker +0.1 WETH). The demo script was removed after verification.

## Update script

`yarn install --frozen-lockfile`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce39e294-1e5b-4065-a3ff-7f15a51f476d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce39e294-1e5b-4065-a3ff-7f15a51f476d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

