### PR TITLE
feat: DelegatedMaker — one-transaction, no-signature, no-escrow maker flow

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -8,6 +8,7 @@ module.exports = {
     ORDER_REGISTRATOR: constants.orderRegistrator || {},
     FEE_TAKER_SALT: constants.feeTakerSalt || {},
     FUSION_ANCHORED_AUCTION_SALT: constants.fusionAnchoredAuctionSalt || {},
+    DELEGATED_MAKER_SALT: constants.delegatedMakerSalt || {},
     PERMIT2_PROXY_SALT: constants.permit2ProxySalt || {},
     PERMIT2_WITNESS_PROXY_SALT: constants.permit2WitnessProxySalt || {},
     NATIVE_ORDER_SALT: constants.nativeOrderSalt || {},

--- a/config/constants.json
+++ b/config/constants.json
@@ -81,5 +81,8 @@
   },
   "fusionAnchoredAuctionSalt": {
     "31337": "FusionAnchoredAuction"
+  },
+  "delegatedMakerSalt": {
+    "31337": "DelegatedMaker"
   }
 }

--- a/contracts/helpers/DelegatedMaker.sol
+++ b/contracts/helpers/DelegatedMaker.sol
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.30;
+
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import { Address, AddressLib } from "@1inch/solidity-utils/contracts/libraries/AddressLib.sol";
+import { SafeERC20, IERC20 } from "@1inch/solidity-utils/contracts/libraries/SafeERC20.sol";
+
+import { IOrderMixin } from "../interfaces/IOrderMixin.sol";
+import { IOrderRegistrator } from "../interfaces/IOrderRegistrator.sol";
+import { IPreInteraction } from "../interfaces/IPreInteraction.sol";
+import { MakerTraits, MakerTraitsLib } from "../libraries/MakerTraitsLib.sol";
+import { ExtensionLib } from "../libraries/ExtensionLib.sol";
+
+/**
+ * @title DelegatedMaker
+ * @notice A shared order maker that gives ERC-20 makers a one-transaction, no-signature, no-escrow flow.
+ * @dev A user sends a single {createOrder} transaction and signs nothing: the contract records the user
+ * as the order's owner — the presign read by {isValidSignature} at fill time — and registers the order,
+ * anchoring any announcement-based auction in the same block. Funds never move at creation. The order
+ * names this contract as its maker, so at fill time the protocol calls {preInteraction} immediately
+ * before the maker-asset transfer, and the contract pulls exactly the filled amount from the owner's
+ * wallet through their standing allowance. Custody time is zero; proceeds go straight to the owner,
+ * because {createOrder} requires the order's receiver to be the owner.
+ *
+ * The token path has two allowances: the owner's allowance to this contract feeds the just-in-time pull,
+ * and this contract's own allowance to the protocol lets the protocol move the pulled funds to the
+ * taker. The latter is self-provisioned: {preInteraction} tops it up to the maximum whenever it runs
+ * short, which is once per token for tokens that leave infinite allowances undecremented and
+ * automatically again for tokens that spend them down. Unbounded is safe here because the protocol
+ * only transfers within valid fills of orders this contract has presigned.
+ *
+ * The contract concentrates standing allowances, the same trust shape as the protocol itself; it holds
+ * no balances between transactions and has no owner powers over user funds. Contract wallets can use it
+ * the same way EOAs do, though a Safe keeps cleaner provenance staying its own maker — one MultiSend
+ * batch marking the digest through SignMessageLib and calling {OrderRegistrator-registerOrder}.
+ *
+ * A non-creator receiver is accepted in exactly one shape: fee collection. {FeeTaker}-layout settlement
+ * contracts only take fees when the order's receiver is the fee contract itself, and they pay the
+ * maker's share to the order's maker — this contract, which cannot withdraw — unless their fee data
+ * carries a custom receiver. So a fee-collecting order is allowed when the order's own bytes route the
+ * proceeds home: the post-interaction must target the receiver (which is {FeeTaker}'s own distribution
+ * condition) and must carry the custom-receiver flag naming the creator. That guarantees a conforming
+ * fee contract forwards the net to the wallet that funded the order; the fee contract itself is the
+ * creator's choice and trust, and naming a hostile one harms only the creator, whose funds alone back
+ * the order.
+ */
+contract DelegatedMaker is IERC1271, IPreInteraction {
+    using AddressLib for Address;
+    using SafeERC20 for IERC20;
+    using MakerTraitsLib for MakerTraits;
+    using ExtensionLib for bytes;
+
+    /// @dev The function may only be called by the limit order protocol.
+    error OnlyLimitOrderProtocol();
+    /// @dev The order's maker must be this contract.
+    error InvalidMaker();
+    /// @dev The order's receiver must be the creating owner, so proceeds bypass the shared contract.
+    error InvalidReceiver();
+    /// @dev A non-creator receiver is only allowed when the post-interaction targets that receiver and
+    /// its fee data names the creator as the custom receiver — the verified fee-collection shape.
+    error InvalidFeeReceiver();
+    /// @dev Orders must use the per-order remaining invalidator and the pre-interaction hook.
+    error InvalidMakerTraits();
+    /// @dev The order's pre-interaction must target this contract, or the pull never happens.
+    error InvalidPreInteractionTarget();
+    /// @dev The order was registered before; a cancelled order cannot be revived either.
+    error OrderAlreadyRegistered();
+    /// @dev Only the recorded owner of the order may act on it.
+    error AccessDenied();
+
+    /// @dev Mirrors {FeeTaker}'s private custom-receiver flag: the first byte of its post-interaction
+    /// data sets 0x01 when a receiver of the maker's share follows the two fee recipients.
+    bytes1 private constant _CUSTOM_RECEIVER_FLAG = 0x01;
+    /// @dev Where {FeeTaker}'s custom receiver sits in the post-interaction field: 20 bytes of target,
+    /// then 1 byte of flags and two 20-byte fee recipients.
+    uint256 private constant _CUSTOM_RECEIVER_OFFSET = 61;
+
+    /**
+     * @notice Emitted when an order is created and presigned on behalf of an owner.
+     * @param orderHash The hash of the created order.
+     * @param owner The wallet whose funds the order draws on.
+     */
+    event DelegatedOrderCreated(bytes32 indexed orderHash, address indexed owner);
+
+    /**
+     * @notice Emitted when an owner cancels their order.
+     * @param orderHash The hash of the cancelled order.
+     */
+    event DelegatedOrderCancelled(bytes32 indexed orderHash);
+
+    IOrderMixin private immutable _LIMIT_ORDER_PROTOCOL;
+    IOrderRegistrator private immutable _ORDER_REGISTRATOR;
+
+    /// @notice The wallet each order draws funds from — the presign, deleted on cancellation.
+    mapping(bytes32 orderHash => address owner) public approvedOrders;
+
+    constructor(IOrderMixin limitOrderProtocol, IOrderRegistrator orderRegistrator) {
+        _LIMIT_ORDER_PROTOCOL = limitOrderProtocol;
+        _ORDER_REGISTRATOR = orderRegistrator;
+    }
+
+    /**
+     * @notice Creates, presigns and announces an order on behalf of the caller — the only per-order
+     * transaction, with nothing signed off-chain.
+     * @dev The order must name this contract as maker, must use the remaining invalidator (partial and
+     * multiple fills allowed — the bit-invalidator nonce space would be shared across users), and must
+     * route its pre-interaction to this contract (an absent pre-interaction target defaults to the
+     * order's maker, which is this contract). The receiver is the caller, or a fee contract in the
+     * verified fee-collection shape (see {_createOrder}). The duplicate check reads the registrator
+     * rather than local state: a cancelled order deletes its local approval, but its protocol-level
+     * invalidation is permanent, so re-creating it would only produce a dead order.
+     * @param order The order to create; its maker is this contract, its funds are the caller's.
+     * @param extension The extension data associated with the order.
+     */
+    function createOrder(IOrderMixin.Order calldata order, bytes calldata extension) external {
+        _createOrder(order, extension);
+    }
+
+    /**
+     * @notice {createOrder}, with the maker-asset allowance folded into the same transaction for
+     * EIP-2612 tokens — the first order needs no separate approval.
+     * @dev The permit's owner is pinned to the caller and its spender is this contract, so a foreign
+     * permit cannot be attached to a foreign order. Permit failure is swallowed deliberately, the same
+     * way the protocol treats maker permits: a front-run permit has already granted the allowance, and
+     * a wrong one leaves the order created and anchored but unfillable until an allowance exists — a
+     * later approval revives it, and nothing needs refunding because nothing moved.
+     * @param order The order to create; its maker is this contract, its funds are the caller's.
+     * @param extension The extension data associated with the order.
+     * @param permit The EIP-2612 permit for the order's maker asset, spender being this contract.
+     */
+    function createOrderWithPermit(IOrderMixin.Order calldata order, bytes calldata extension, bytes calldata permit) external {
+        IERC20(order.makerAsset.get()).tryPermit(msg.sender, address(this), permit);
+        _createOrder(order, extension);
+    }
+
+    /**
+     * @dev The shared create path. Proceeds must route to the creator one way or the other: directly,
+     * with the caller as receiver, or through a fee contract that is both the order's receiver and its
+     * post-interaction target — {FeeTaker}'s own distribution condition — with the custom-receiver flag
+     * set and the creator in the custom-receiver slot. Anything else strands the taking asset on a
+     * contract with no path back to the wallet that funded the fill.
+     */
+    function _createOrder(IOrderMixin.Order calldata order, bytes calldata extension) private {
+        if (order.maker.get() != address(this)) revert InvalidMaker();
+
+        address receiver = order.receiver.get();
+        if (receiver == address(0)) revert InvalidReceiver();
+        if (receiver != msg.sender) {
+            bytes calldata postInteractionData = extension.postInteractionTargetAndData();
+            if (
+                !order.makerTraits.needPostInteractionCall() ||
+                postInteractionData.length < _CUSTOM_RECEIVER_OFFSET + 20 ||
+                address(bytes20(postInteractionData)) != receiver ||
+                postInteractionData[20] & _CUSTOM_RECEIVER_FLAG == 0 ||
+                address(bytes20(postInteractionData[_CUSTOM_RECEIVER_OFFSET:_CUSTOM_RECEIVER_OFFSET + 20])) != msg.sender
+            ) revert InvalidFeeReceiver();
+        }
+
+        if (order.makerTraits.useBitInvalidator() || !order.makerTraits.needPreInteractionCall()) revert InvalidMakerTraits();
+        bytes calldata preInteractionData = extension.preInteractionTargetAndData();
+        if (preInteractionData.length >= 20 && address(bytes20(preInteractionData)) != address(this)) revert InvalidPreInteractionTarget();
+
+        bytes32 orderHash = _LIMIT_ORDER_PROTOCOL.hashOrder(order);
+        if (_ORDER_REGISTRATOR.announcedAt(orderHash) != 0) revert OrderAlreadyRegistered();
+
+        approvedOrders[orderHash] = msg.sender;
+        emit DelegatedOrderCreated(orderHash, msg.sender);
+
+        _ORDER_REGISTRATOR.registerOrder(order, extension);
+    }
+
+    /**
+     * @notice Cancels an order previously created by the caller.
+     * @dev Deletes the presign and invalidates the order at the protocol as its maker. Both matter: the
+     * protocol validates ERC-1271 only on the first fill, so deleting the presign alone would not stop
+     * further partial fills of an already-started order — the protocol-level invalidation kills those,
+     * and the per-fill owner check in {preInteraction} backs that up.
+     * @param order The order to cancel.
+     */
+    function cancelOrder(IOrderMixin.Order calldata order) external {
+        bytes32 orderHash = _LIMIT_ORDER_PROTOCOL.hashOrder(order);
+        if (approvedOrders[orderHash] != msg.sender) revert AccessDenied();
+        delete approvedOrders[orderHash];
+        emit DelegatedOrderCancelled(orderHash);
+
+        _LIMIT_ORDER_PROTOCOL.cancelOrder(order.makerTraits, orderHash);
+    }
+
+    /**
+     * @notice See {IERC1271-isValidSignature}. The presign: a hash is signed while its order is approved.
+     * @dev The signature bytes are ignored — authorization was given on-chain in {createOrder} — so fills
+     * pass an empty signature.
+     */
+    function isValidSignature(bytes32 hash, bytes calldata /* signature */) external view returns (bytes4) {
+        return approvedOrders[hash] != address(0) ? this.isValidSignature.selector : bytes4(0);
+    }
+
+    /**
+     * @notice See {IPreInteraction-preInteraction}. Pulls exactly the filled amount from the order's
+     * owner immediately before the protocol moves the maker asset to the taker.
+     * @dev Checked on every fill, not just the first: a cancelled order has no owner on record and
+     * cannot pull, whatever state the fill reached the protocol in. The protocol's own allowance for
+     * the maker asset is topped up here when it runs short, so a token's first fill provisions it and
+     * nothing else has to.
+     */
+    function preInteraction(
+        IOrderMixin.Order calldata order,
+        bytes calldata /* extension */,
+        bytes32 orderHash,
+        address /* taker */,
+        uint256 makingAmount,
+        uint256 /* takingAmount */,
+        uint256 /* remainingMakingAmount */,
+        bytes calldata /* extraData */
+    ) external {
+        if (msg.sender != address(_LIMIT_ORDER_PROTOCOL)) revert OnlyLimitOrderProtocol();
+        address owner = approvedOrders[orderHash];
+        if (owner == address(0)) revert AccessDenied();
+
+        IERC20 makerAsset = IERC20(order.makerAsset.get());
+        if (makerAsset.allowance(address(this), address(_LIMIT_ORDER_PROTOCOL)) < makingAmount) {
+            makerAsset.forceApprove(address(_LIMIT_ORDER_PROTOCOL), type(uint256).max);
+        }
+        makerAsset.safeTransferFrom(owner, address(this), makingAmount);
+    }
+}

--- a/contracts/helpers/OrderRegistrator.sol
+++ b/contracts/helpers/OrderRegistrator.sol
@@ -13,7 +13,7 @@ import { OrderLib } from "../OrderLib.sol";
  * @dev Registration is authenticated by the transaction itself: only the order's maker may call
  * {registerOrder}, so no signature is taken and none is checked. The emitted order therefore always
  * originates from its maker, but carries no fill authorization — that lives wherever each flow keeps it
- * (presign state for contract makers such as Safes, the off-chain orderbook for
+ * (presign state for contract makers such as {DelegatedMaker} and Safes, the off-chain orderbook for
  * EOA fill signatures). Neither the broadcast nor the clock can be delegated to a relayer.
  *
  * The recorded announcement is what {FusionAnchoredAuction} anchors an auction to, so it is written

--- a/deploy/deploy-delegated-maker.js
+++ b/deploy/deploy-delegated-maker.js
@@ -1,0 +1,61 @@
+const { deployAndGetContractWithCreate3, deployAndGetContract } = require('@1inch/solidity-utils');
+const hre = require('hardhat');
+const { ethers, getChainId } = hre;
+const constants = require('../config/constants');
+
+module.exports = async ({ deployments, getNamedAccounts }) => {
+    const networkName = hre.network.name;
+    console.log(`running ${networkName} deploy script`);
+    const chainId = await getChainId();
+    console.log('network id ', chainId);
+
+    if (
+        networkName in hre.config.networks &&
+        chainId !== hre.config.networks[networkName].chainId?.toString()
+    ) {
+        console.log(`network chain id: ${hre.config.networks[networkName].chainId}, your chain id ${chainId}`);
+        console.log('skipping wrong chain id deployment');
+        return;
+    }
+
+    const orderRegistrator = constants.ORDER_REGISTRATOR[chainId];
+    if (!orderRegistrator || orderRegistrator === ethers.ZeroAddress) {
+        // The registrator is immutable in the helper, and every created order announces through it, so an
+        // unset one produces a helper whose createOrder always reverts.
+        throw new Error(
+            `No OrderRegistrator configured for chain ${chainId}. DelegatedMaker registers orders with ` +
+            'it, so deploy the registrator first and record its address in config/constants.json.',
+        );
+    }
+
+    const constructorArgs = [constants.ROUTER_V6[chainId], orderRegistrator];
+
+    if (networkName.indexOf('zksync') !== -1) { // create3 is not supported for zksync
+        const { deployer } = await getNamedAccounts();
+
+        await deployAndGetContract({
+            contractName: 'DelegatedMaker',
+            constructorArgs,
+            deployments,
+            deployer,
+            skipVerify: process.env.OPS_SKIP_VERIFY === 'true',
+        });
+    } else {
+        const salt = constants.DELEGATED_MAKER_SALT[chainId].startsWith('0x')
+            ? constants.DELEGATED_MAKER_SALT[chainId]
+            : ethers.keccak256(ethers.toUtf8Bytes(constants.DELEGATED_MAKER_SALT[chainId]));
+
+        console.log(`Using salt: ${salt}`);
+
+        await deployAndGetContractWithCreate3({
+            contractName: 'DelegatedMaker',
+            constructorArgs,
+            create3Deployer: constants.CREATE3_DEPLOYER[chainId],
+            salt,
+            deployments,
+            skipVerify: process.env.OPS_SKIP_VERIFY === 'true',
+        });
+    }
+};
+
+module.exports.skip = async () => true;

--- a/docs/helpers/DelegatedMaker.md
+++ b/docs/helpers/DelegatedMaker.md
@@ -1,0 +1,244 @@
+
+## DelegatedMaker
+
+A shared order maker that gives ERC-20 makers a one-transaction, no-signature, no-escrow flow.
+
+_A user sends a single {createOrder} transaction and signs nothing: the contract records the user
+as the order's owner — the presign read by {isValidSignature} at fill time — and registers the order,
+anchoring any announcement-based auction in the same block. Funds never move at creation. The order
+names this contract as its maker, so at fill time the protocol calls {preInteraction} immediately
+before the maker-asset transfer, and the contract pulls exactly the filled amount from the owner's
+wallet through their standing allowance. Custody time is zero; proceeds go straight to the owner,
+because {createOrder} requires the order's receiver to be the owner.
+
+The token path has two allowances: the owner's allowance to this contract feeds the just-in-time pull,
+and this contract's own allowance to the protocol lets the protocol move the pulled funds to the
+taker. The latter is self-provisioned: {preInteraction} tops it up to the maximum whenever it runs
+short, which is once per token for tokens that leave infinite allowances undecremented and
+automatically again for tokens that spend them down. Unbounded is safe here because the protocol
+only transfers within valid fills of orders this contract has presigned.
+
+The contract concentrates standing allowances, the same trust shape as the protocol itself; it holds
+no balances between transactions and has no owner powers over user funds. Contract wallets can use it
+the same way EOAs do, though a Safe keeps cleaner provenance staying its own maker — one MultiSend
+batch marking the digest through SignMessageLib and calling {OrderRegistrator-registerOrder}.
+
+A non-creator receiver is accepted in exactly one shape: fee collection. {FeeTaker}-layout settlement
+contracts only take fees when the order's receiver is the fee contract itself, and they pay the
+maker's share to the order's maker — this contract, which cannot withdraw — unless their fee data
+carries a custom receiver. So a fee-collecting order is allowed when the order's own bytes route the
+proceeds home: the post-interaction must target the receiver (which is {FeeTaker}'s own distribution
+condition) and must carry the custom-receiver flag naming the creator. That guarantees a conforming
+fee contract forwards the net to the wallet that funded the order; the fee contract itself is the
+creator's choice and trust, and naming a hostile one harms only the creator, whose funds alone back
+the order._
+
+### Functions list
+- [constructor(limitOrderProtocol, orderRegistrator) public](#constructor)
+- [createOrder(order, extension) external](#createorder)
+- [createOrderWithPermit(order, extension, permit) external](#createorderwithpermit)
+- [cancelOrder(order) external](#cancelorder)
+- [isValidSignature(hash, ) external](#isvalidsignature)
+- [preInteraction(order, , orderHash, , makingAmount, , , ) external](#preinteraction)
+
+### Events list
+- [DelegatedOrderCreated(orderHash, owner) ](#delegatedordercreated)
+- [DelegatedOrderCancelled(orderHash) ](#delegatedordercancelled)
+
+### Errors list
+- [OnlyLimitOrderProtocol() ](#onlylimitorderprotocol)
+- [InvalidMaker() ](#invalidmaker)
+- [InvalidReceiver() ](#invalidreceiver)
+- [InvalidFeeReceiver() ](#invalidfeereceiver)
+- [InvalidMakerTraits() ](#invalidmakertraits)
+- [InvalidPreInteractionTarget() ](#invalidpreinteractiontarget)
+- [OrderAlreadyRegistered() ](#orderalreadyregistered)
+- [AccessDenied() ](#accessdenied)
+
+### Functions
+### constructor
+
+```solidity
+constructor(contract IOrderMixin limitOrderProtocol, contract IOrderRegistrator orderRegistrator) public
+```
+
+### createOrder
+
+```solidity
+function createOrder(struct IOrderMixin.Order order, bytes extension) external
+```
+Creates, presigns and announces an order on behalf of the caller — the only per-order
+transaction, with nothing signed off-chain.
+
+_The order must name this contract as maker, must use the remaining invalidator (partial and
+multiple fills allowed — the bit-invalidator nonce space would be shared across users), and must
+route its pre-interaction to this contract (an absent pre-interaction target defaults to the
+order's maker, which is this contract). The receiver is the caller, or a fee contract in the
+verified fee-collection shape (see {_createOrder}). The duplicate check reads the registrator
+rather than local state: a cancelled order deletes its local approval, but its protocol-level
+invalidation is permanent, so re-creating it would only produce a dead order._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| order | struct IOrderMixin.Order | The order to create; its maker is this contract, its funds are the caller's. |
+| extension | bytes | The extension data associated with the order. |
+
+### createOrderWithPermit
+
+```solidity
+function createOrderWithPermit(struct IOrderMixin.Order order, bytes extension, bytes permit) external
+```
+{createOrder}, with the maker-asset allowance folded into the same transaction for
+EIP-2612 tokens — the first order needs no separate approval.
+
+_The permit's owner is pinned to the caller and its spender is this contract, so a foreign
+permit cannot be attached to a foreign order. Permit failure is swallowed deliberately, the same
+way the protocol treats maker permits: a front-run permit has already granted the allowance, and
+a wrong one leaves the order created and anchored but unfillable until an allowance exists — a
+later approval revives it, and nothing needs refunding because nothing moved._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| order | struct IOrderMixin.Order | The order to create; its maker is this contract, its funds are the caller's. |
+| extension | bytes | The extension data associated with the order. |
+| permit | bytes | The EIP-2612 permit for the order's maker asset, spender being this contract. |
+
+### cancelOrder
+
+```solidity
+function cancelOrder(struct IOrderMixin.Order order) external
+```
+Cancels an order previously created by the caller.
+
+_Deletes the presign and invalidates the order at the protocol as its maker. Both matter: the
+protocol validates ERC-1271 only on the first fill, so deleting the presign alone would not stop
+further partial fills of an already-started order — the protocol-level invalidation kills those,
+and the per-fill owner check in {preInteraction} backs that up._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| order | struct IOrderMixin.Order | The order to cancel. |
+
+### isValidSignature
+
+```solidity
+function isValidSignature(bytes32 hash, bytes) external view returns (bytes4)
+```
+See {IERC1271-isValidSignature}. The presign: a hash is signed while its order is approved.
+
+_The signature bytes are ignored — authorization was given on-chain in {createOrder} — so fills
+pass an empty signature._
+
+### preInteraction
+
+```solidity
+function preInteraction(struct IOrderMixin.Order order, bytes, bytes32 orderHash, address, uint256 makingAmount, uint256, uint256, bytes) external
+```
+See {IPreInteraction-preInteraction}. Pulls exactly the filled amount from the order's
+owner immediately before the protocol moves the maker asset to the taker.
+
+_Checked on every fill, not just the first: a cancelled order has no owner on record and
+cannot pull, whatever state the fill reached the protocol in. The protocol's own allowance for
+the maker asset is topped up here when it runs short, so a token's first fill provisions it and
+nothing else has to._
+
+### Events
+### DelegatedOrderCreated
+
+```solidity
+event DelegatedOrderCreated(bytes32 orderHash, address owner)
+```
+Emitted when an order is created and presigned on behalf of an owner.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| orderHash | bytes32 | The hash of the created order. |
+| owner | address | The wallet whose funds the order draws on. |
+
+### DelegatedOrderCancelled
+
+```solidity
+event DelegatedOrderCancelled(bytes32 orderHash)
+```
+Emitted when an owner cancels their order.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| orderHash | bytes32 | The hash of the cancelled order. |
+
+### Errors
+### OnlyLimitOrderProtocol
+
+```solidity
+error OnlyLimitOrderProtocol()
+```
+
+_The function may only be called by the limit order protocol._
+
+### InvalidMaker
+
+```solidity
+error InvalidMaker()
+```
+
+_The order's maker must be this contract._
+
+### InvalidReceiver
+
+```solidity
+error InvalidReceiver()
+```
+
+_The order's receiver must be the creating owner, so proceeds bypass the shared contract._
+
+### InvalidFeeReceiver
+
+```solidity
+error InvalidFeeReceiver()
+```
+
+_A non-creator receiver is only allowed when the post-interaction targets that receiver and
+its fee data names the creator as the custom receiver — the verified fee-collection shape._
+
+### InvalidMakerTraits
+
+```solidity
+error InvalidMakerTraits()
+```
+
+_Orders must use the per-order remaining invalidator and the pre-interaction hook._
+
+### InvalidPreInteractionTarget
+
+```solidity
+error InvalidPreInteractionTarget()
+```
+
+_The order's pre-interaction must target this contract, or the pull never happens._
+
+### OrderAlreadyRegistered
+
+```solidity
+error OrderAlreadyRegistered()
+```
+
+_The order was registered before; a cancelled order cannot be revived either._
+
+### AccessDenied
+
+```solidity
+error AccessDenied()
+```
+
+_Only the recorded owner of the order may act on it._
+

--- a/docs/helpers/OrderRegistrator.md
+++ b/docs/helpers/OrderRegistrator.md
@@ -6,7 +6,7 @@ Announces orders on-chain and records when each one was first announced.
 _Registration is authenticated by the transaction itself: only the order's maker may call
 {registerOrder}, so no signature is taken and none is checked. The emitted order therefore always
 originates from its maker, but carries no fill authorization — that lives wherever each flow keeps it
-(presign state for contract makers such as Safes, the off-chain orderbook for
+(presign state for contract makers such as {DelegatedMaker} and Safes, the off-chain orderbook for
 EOA fill signatures). Neither the broadcast nor the clock can be delegated to a relayer.
 
 The recorded announcement is what {FusionAnchoredAuction} anchors an auction to, so it is written

--- a/test/DelegatedMaker.js
+++ b/test/DelegatedMaker.js
@@ -1,0 +1,575 @@
+const hre = require('hardhat');
+const { ethers } = hre;
+const { expect } = require('@1inch/solidity-utils');
+const { loadFixture, time } = require('@nomicfoundation/hardhat-network-helpers');
+const { deploySwapTokens } = require('./helpers/fixtures');
+const {
+    buildAnchoredAuctionDetails,
+    buildAnchoredExclusivity,
+    buildFeeTakerExtensions,
+    buildMakerTraitsRFQ,
+    buildOrder,
+    buildTakerTraits,
+} = require('./helpers/orderUtils');
+const { ether, trim0x } = require('./helpers/utils');
+const { getPermit } = require('./helpers/eip712');
+const { BASE_POINTS, ceilDiv, takingAmountFor } = require('./helpers/fusionAuction');
+
+const HALF_PERCENT = 50_000n; // 0.5% in 1e7
+
+describe('DelegatedMaker', function () {
+    let user, user2, taker, stranger;
+
+    before(async function () {
+        [user, user2, taker, stranger] = await ethers.getSigners();
+    });
+
+    const MAKING_AMOUNT = ether('100');
+    const TAKING_AMOUNT = ether('0.1');
+
+    async function deployContractsAndInit () {
+        const { dai, weth, inch, swap, chainId } = await deploySwapTokens();
+
+        const OrderRegistrator = await ethers.getContractFactory('OrderRegistrator');
+        const registrator = await OrderRegistrator.deploy(swap);
+        await registrator.waitForDeployment();
+
+        const FusionAnchoredAuction = await ethers.getContractFactory('FusionAnchoredAuction');
+        const auction = await FusionAnchoredAuction.deploy(registrator);
+        await auction.waitForDeployment();
+
+        const DelegatedMaker = await ethers.getContractFactory('DelegatedMaker');
+        const delegatedMaker = await DelegatedMaker.deploy(swap, registrator);
+        await delegatedMaker.waitForDeployment();
+
+        const FeeTaker = await ethers.getContractFactory('FeeTaker');
+        const feeTaker = await FeeTaker.deploy(swap, inch, weth, user);
+        await feeTaker.waitForDeployment();
+
+        // The owners' one-time setup: funds stay in the wallet, only an allowance is granted.
+        await dai.mint(user, ether('1000000'));
+        await dai.connect(user).approve(delegatedMaker, ether('1000000'));
+        await dai.mint(user2, ether('1000000'));
+        await dai.connect(user2).approve(delegatedMaker, ether('1000000'));
+
+        await weth.connect(taker).deposit({ value: ether('100') });
+        await weth.connect(taker).approve(swap, ether('100'));
+        // The taker pays dai in the permit tests and holds the access token in the fee tests.
+        await dai.mint(taker, ether('1000000'));
+        await dai.connect(taker).approve(swap, ether('1000000'));
+        await inch.mint(taker, ether('1'));
+
+        return { dai, weth, inch, swap, chainId, registrator, auction, delegatedMaker, feeTaker };
+    }
+
+    /** An order the shared contract makes on behalf of `owner`, funded from the owner's wallet. */
+    async function buildDelegatedOrder ({ dai, weth, delegatedMaker, owner = user, auctionData, makingAmount = MAKING_AMOUNT }) {
+        const delegatedMakerAddress = await delegatedMaker.getAddress();
+        return buildOrder(
+            {
+                maker: delegatedMakerAddress,
+                receiver: owner.address,
+                makerAsset: await dai.getAddress(),
+                takerAsset: await weth.getAddress(),
+                makingAmount,
+                takingAmount: TAKING_AMOUNT,
+            },
+            {
+                ...(auctionData ? { makingAmountData: auctionData, takingAmountData: auctionData } : {}),
+                preInteraction: delegatedMakerAddress,
+            },
+        );
+    }
+
+    function fill (swap, order, amount, { byMakingAmount = true, from = taker } = {}) {
+        const takerTraits = buildTakerTraits({ makingAmount: byMakingAmount, extension: order.extension });
+        return swap.connect(from).fillContractOrderArgs(order, '0x', amount, takerTraits.traits, takerTraits.args);
+    }
+
+    describe('lifecycle', function () {
+        it('creates, anchors and presigns in one transaction, moving nothing', async function () {
+            const { dai, weth, swap, registrator, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            const orderHash = await swap.hashOrder(order);
+
+            const tx = await delegatedMaker.connect(user).createOrder(order, order.extension);
+            await tx.wait();
+
+            await expect(tx).to.emit(delegatedMaker, 'DelegatedOrderCreated').withArgs(orderHash, user.address);
+            await expect(tx).to.emit(registrator, 'OrderAnnounced');
+
+            expect(await delegatedMaker.approvedOrders(orderHash)).to.equal(user.address);
+            expect(await registrator.announcedAt(orderHash)).to.equal(await time.latest());
+            // The presign is live and the wallet untouched: nothing moved and nothing was signed.
+            expect(await delegatedMaker.isValidSignature(orderHash, '0x')).to.equal('0x1626ba7e');
+            expect(await dai.balanceOf(user)).to.equal(ether('1000000'));
+            expect(await dai.balanceOf(delegatedMaker)).to.equal(0);
+        });
+
+        it('fills with an empty signature, pulling funds just in time', async function () {
+            const { dai, weth, swap, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            await delegatedMaker.connect(user).createOrder(order, order.extension);
+
+            const fillTx = fill(swap, order, MAKING_AMOUNT);
+            // The pull, the fill and the payout are one transaction: the wallet funds the order at the
+            // moment it fills, the shared contract keeps nothing, and proceeds land on the owner directly.
+            await expect(fillTx).to.changeTokenBalances(dai, [user, taker, delegatedMaker], [-MAKING_AMOUNT, MAKING_AMOUNT, 0]);
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, user], [-TAKING_AMOUNT, TAKING_AMOUNT]);
+        });
+
+        it('pulls exactly the filled amount across partial fills', async function () {
+            const { dai, weth, swap, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            await delegatedMaker.connect(user).createOrder(order, order.extension);
+
+            const first = MAKING_AMOUNT * 2n / 5n;
+            await expect(fill(swap, order, first))
+                .to.changeTokenBalances(dai, [user, taker, delegatedMaker], [-first, first, 0]);
+
+            const rest = MAKING_AMOUNT - first;
+            const restTx = fill(swap, order, rest);
+            await expect(restTx).to.changeTokenBalances(dai, [user, taker, delegatedMaker], [-rest, rest, 0]);
+            await expect(restTx).to.changeTokenBalances(weth, [taker, user], [-TAKING_AMOUNT * 3n / 5n, TAKING_AMOUNT * 3n / 5n]);
+        });
+    });
+
+    describe('creation rules', function () {
+        it('rejects an order that does not name this contract as maker', async function () {
+            const { dai, weth, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            order.maker = user.address;
+            await expect(delegatedMaker.connect(user).createOrder(order, order.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidMaker');
+        });
+
+        it('rejects an order whose receiver is not the creator', async function () {
+            const { dai, weth, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            // A zero receiver would pay the order's maker — this contract — and a foreign receiver is
+            // only acceptable in the verified fee-collection shape, which a bare order does not carry.
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            await expect(delegatedMaker.connect(user2).createOrder(order, order.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidFeeReceiver');
+
+            const zeroReceiver = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            zeroReceiver.receiver = ethers.ZeroAddress;
+            await expect(delegatedMaker.connect(user).createOrder(zeroReceiver, zeroReceiver.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidReceiver');
+        });
+
+        it('rejects bit-invalidator traits and a missing pre-interaction hook', async function () {
+            const { dai, weth, delegatedMaker } = await loadFixture(deployContractsAndInit);
+            const delegatedMakerAddress = await delegatedMaker.getAddress();
+
+            // The bit-invalidator nonce space would be shared across every user of the contract.
+            const rfqStyle = buildOrder(
+                {
+                    maker: delegatedMakerAddress,
+                    receiver: user.address,
+                    makerAsset: await dai.getAddress(),
+                    takerAsset: await weth.getAddress(),
+                    makingAmount: MAKING_AMOUNT,
+                    takingAmount: TAKING_AMOUNT,
+                    makerTraits: buildMakerTraitsRFQ(),
+                },
+                { preInteraction: delegatedMakerAddress },
+            );
+            await expect(delegatedMaker.connect(user).createOrder(rfqStyle, rfqStyle.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidMakerTraits');
+
+            // Without the pre-interaction hook no pull ever happens and the order could never fill.
+            const noHook = buildOrder({
+                maker: delegatedMakerAddress,
+                receiver: user.address,
+                makerAsset: await dai.getAddress(),
+                takerAsset: await weth.getAddress(),
+                makingAmount: MAKING_AMOUNT,
+                takingAmount: TAKING_AMOUNT,
+            });
+            await expect(delegatedMaker.connect(user).createOrder(noHook, noHook.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidMakerTraits');
+        });
+
+        it('rejects a pre-interaction that targets a foreign contract', async function () {
+            const { dai, weth, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const order = buildOrder(
+                {
+                    maker: await delegatedMaker.getAddress(),
+                    receiver: user.address,
+                    makerAsset: await dai.getAddress(),
+                    takerAsset: await weth.getAddress(),
+                    makingAmount: MAKING_AMOUNT,
+                    takingAmount: TAKING_AMOUNT,
+                },
+                { preInteraction: taker.address },
+            );
+            await expect(delegatedMaker.connect(user).createOrder(order, order.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidPreInteractionTarget');
+        });
+
+        it('rejects a duplicate and a cancelled order alike', async function () {
+            const { dai, weth, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            await delegatedMaker.connect(user).createOrder(order, order.extension);
+            await expect(delegatedMaker.connect(user).createOrder(order, order.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'OrderAlreadyRegistered');
+
+            // Re-creating a cancelled order would re-arm the presign for an order the protocol has
+            // invalidated forever — a paid-for dead order. The ever-registered check refuses it.
+            await delegatedMaker.connect(user).cancelOrder(order);
+            await expect(delegatedMaker.connect(user).createOrder(order, order.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'OrderAlreadyRegistered');
+        });
+    });
+
+    describe('cancellation', function () {
+        it('kills an already-started order at the protocol level', async function () {
+            const { dai, weth, swap, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            const orderHash = await swap.hashOrder(order);
+            await delegatedMaker.connect(user).createOrder(order, order.extension);
+
+            const first = MAKING_AMOUNT / 2n;
+            await expect(fill(swap, order, first)).to.changeTokenBalances(dai, [user, taker], [-first, first]);
+
+            // The protocol validates ERC-1271 only on the first fill, so deleting the presign alone would
+            // not stop the rest of a started order — the cancellation invalidates it at the protocol too.
+            const cancelTx = delegatedMaker.connect(user).cancelOrder(order);
+            await expect(cancelTx).to.emit(delegatedMaker, 'DelegatedOrderCancelled').withArgs(orderHash);
+            expect(await delegatedMaker.approvedOrders(orderHash)).to.equal(ethers.ZeroAddress);
+            expect(await delegatedMaker.isValidSignature(orderHash, '0x')).to.equal('0x00000000');
+
+            await expect(fill(swap, order, MAKING_AMOUNT - first)).to.be.revertedWithCustomError(swap, 'InvalidatedOrder');
+        });
+
+        it('is the recorded owner\'s alone to call', async function () {
+            const { dai, weth, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            await delegatedMaker.connect(user).createOrder(order, order.extension);
+
+            await expect(delegatedMaker.connect(user2).cancelOrder(order))
+                .to.be.revertedWithCustomError(delegatedMaker, 'AccessDenied');
+            // An order that was never created has no owner either.
+            const foreign = await buildDelegatedOrder({ dai, weth, delegatedMaker, makingAmount: MAKING_AMOUNT / 2n });
+            await expect(delegatedMaker.connect(user).cancelOrder(foreign))
+                .to.be.revertedWithCustomError(delegatedMaker, 'AccessDenied');
+        });
+    });
+
+    describe('pull authorization', function () {
+        it('rejects pulls from anyone but the protocol, and for orders with no owner', async function () {
+            const { dai, weth, swap, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker });
+            const orderHash = await swap.hashOrder(order);
+            await delegatedMaker.connect(user).createOrder(order, order.extension);
+
+            await expect(
+                delegatedMaker.connect(stranger).preInteraction(order, '0x', orderHash, taker.address, 1n, 1n, 1n, '0x'),
+            ).to.be.revertedWithCustomError(delegatedMaker, 'OnlyLimitOrderProtocol');
+
+            // Even the protocol itself cannot pull for an order with no owner on record — the per-fill
+            // belt to the cancellation suspender.
+            const swapAddress = await swap.getAddress();
+            await ethers.provider.send('hardhat_impersonateAccount', [swapAddress]);
+            await ethers.provider.send('hardhat_setBalance', [swapAddress, '0xde0b6b3a7640000']);
+            const swapSigner = await ethers.getSigner(swapAddress);
+            await expect(
+                delegatedMaker.connect(swapSigner).preInteraction(order, '0x', ethers.id('unapproved'), taker.address, 1n, 1n, 1n, '0x'),
+            ).to.be.revertedWithCustomError(delegatedMaker, 'AccessDenied');
+            await ethers.provider.send('hardhat_stopImpersonatingAccount', [swapAddress]);
+        });
+
+        it('keeps two users on the shared maker out of each other\'s way', async function () {
+            const { dai, weth, swap, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const first = await buildDelegatedOrder({ dai, weth, delegatedMaker, owner: user });
+            const second = await buildDelegatedOrder({ dai, weth, delegatedMaker, owner: user2 });
+            await delegatedMaker.connect(user).createOrder(first, first.extension);
+            await delegatedMaker.connect(user2).createOrder(second, second.extension);
+
+            // The first user's cancellation touches nothing of the second user's order.
+            await delegatedMaker.connect(user).cancelOrder(first);
+            await expect(fill(swap, first, MAKING_AMOUNT)).to.be.revertedWithCustomError(swap, 'InvalidatedOrder');
+
+            const fillTx = fill(swap, second, MAKING_AMOUNT);
+            await expect(fillTx).to.changeTokenBalances(dai, [user2, user, taker], [-MAKING_AMOUNT, 0, MAKING_AMOUNT]);
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, user2, user], [-TAKING_AMOUNT, TAKING_AMOUNT, 0]);
+        });
+    });
+
+    describe('composition with the anchored auction', function () {
+        it('anchors the auction to the create transaction and prices the matrix from it', async function () {
+            const { dai, weth, swap, auction, registrator, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            const params = {
+                startTime: 0,
+                duration: 100,
+                initialRateBump: Number(HALF_PERCENT),
+                anchored: true,
+                fillPremiums: { initial: 400_000, points: [{ premium: 100_000, shareDelta: 5000 }] },
+            };
+            const auctionData = ethers.solidityPacked(
+                ['address', 'bytes'],
+                [await auction.getAddress(), buildAnchoredAuctionDetails(params)],
+            );
+            const order = await buildDelegatedOrder({ dai, weth, delegatedMaker, auctionData });
+            const orderHash = await swap.hashOrder(order);
+
+            await delegatedMaker.connect(user).createOrder(order, order.extension);
+            const announcedAt = Number(await registrator.announcedAt(orderHash));
+            expect(announcedAt).to.equal(await time.latest());
+
+            // Half the order, filled past the auction, pays the matrix premium for its rung — priced from
+            // the create transaction, with no signature anywhere in the flow.
+            const fillTime = announcedAt + 200;
+            await time.setNextBlockTimestamp(fillTime);
+            const makingAmount = MAKING_AMOUNT / 2n;
+            const expected = takingAmountFor(order, { ...params, startTime: announcedAt }, fillTime, makingAmount, MAKING_AMOUNT);
+            expect(expected).to.equal(ceilDiv((TAKING_AMOUNT / 2n) * (BASE_POINTS + 100_000n), BASE_POINTS));
+
+            const fillTx = fill(swap, order, makingAmount);
+            await expect(fillTx).to.changeTokenBalances(dai, [user, taker, delegatedMaker], [-makingAmount, makingAmount, 0]);
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, user], [-expected, expected]);
+        });
+
+        it('carries resolver exclusivity alongside the pull in one order', async function () {
+            const { dai, weth, swap, auction, registrator, delegatedMaker } = await loadFixture(deployContractsAndInit);
+
+            // The production shape: the pre-interaction pulls and the post-interaction gates resolvers,
+            // both hooks on the same order, both anchored to the create transaction.
+            const params = { startTime: 0, duration: 100, initialRateBump: Number(HALF_PERCENT), anchored: true };
+            const auctionAddress = await auction.getAddress();
+            const delegatedMakerAddress = await delegatedMaker.getAddress();
+            const order = buildOrder(
+                {
+                    maker: delegatedMakerAddress,
+                    receiver: user.address,
+                    makerAsset: await dai.getAddress(),
+                    takerAsset: await weth.getAddress(),
+                    makingAmount: MAKING_AMOUNT,
+                    takingAmount: TAKING_AMOUNT,
+                },
+                {
+                    makingAmountData: ethers.solidityPacked(['address', 'bytes'], [auctionAddress, buildAnchoredAuctionDetails(params)]),
+                    takingAmountData: ethers.solidityPacked(['address', 'bytes'], [auctionAddress, buildAnchoredAuctionDetails(params)]),
+                    preInteraction: delegatedMakerAddress,
+                    postInteraction: ethers.solidityPacked(
+                        ['address', 'bytes'],
+                        [auctionAddress, buildAnchoredExclusivity({ allowedTimeDelay: 30, whitelist: [{ address: taker.address }] })],
+                    ),
+                },
+            );
+
+            await delegatedMaker.connect(user).createOrder(order, order.extension);
+            const announcedAt = Number(await registrator.announcedAt(await swap.hashOrder(order)));
+
+            await time.setNextBlockTimestamp(announcedAt + 29);
+            await expect(fill(swap, order, MAKING_AMOUNT)).to.be.revertedWithCustomError(auction, 'AllowedTimeViolation');
+
+            const fillTime = announcedAt + 30;
+            await time.setNextBlockTimestamp(fillTime);
+            const expected = takingAmountFor(order, { ...params, startTime: announcedAt }, fillTime, MAKING_AMOUNT, MAKING_AMOUNT);
+            const fillTx = fill(swap, order, MAKING_AMOUNT);
+            await expect(fillTx).to.changeTokenBalances(dai, [user, taker, delegatedMaker], [-MAKING_AMOUNT, MAKING_AMOUNT, 0]);
+            await expect(fillTx).to.changeTokenBalances(weth, [taker, user], [-expected, expected]);
+        });
+    });
+
+    describe('fee collection', function () {
+        it('collects fees through a fee taker that routes the net back to the creator', async function () {
+            const { dai, weth, swap, registrator, auction, delegatedMaker, feeTaker } = await loadFixture(deployContractsAndInit);
+
+            // The full production shape on one order: the pre-interaction pulls from the creator, the
+            // fee taker is the receiver and pays the creator as its custom receiver, the anchored
+            // auction prices through the fee taker's getters, and the anchored exclusivity rides the
+            // fee taker's post-interaction tail.
+            const resolverFee = 1000n; // 1% in 1e5
+            const auctionParams = { startTime: 0, duration: 100, initialRateBump: Number(HALF_PERCENT), anchored: true };
+            const auctionTail = ethers.solidityPacked(
+                ['address', 'bytes'],
+                [await auction.getAddress(), buildAnchoredAuctionDetails(auctionParams)],
+            );
+            const exclusivityTail = ethers.solidityPacked(
+                ['address', 'bytes'],
+                [await auction.getAddress(), buildAnchoredExclusivity({ allowedTimeDelay: 30, whitelist: [{ address: taker.address }] })],
+            );
+            const delegatedMakerAddress = await delegatedMaker.getAddress();
+
+            const order = buildOrder(
+                {
+                    maker: delegatedMakerAddress,
+                    receiver: await feeTaker.getAddress(),
+                    makerAsset: await dai.getAddress(),
+                    takerAsset: await weth.getAddress(),
+                    makingAmount: MAKING_AMOUNT,
+                    takingAmount: TAKING_AMOUNT,
+                },
+                {
+                    ...buildFeeTakerExtensions({
+                        feeTaker: await feeTaker.getAddress(),
+                        makerReceiver: user.address,
+                        protocolFeeRecipient: stranger.address,
+                        resolverFee,
+                        whitelistDiscount: 100,
+                        customMakingGetter: auctionTail,
+                        customTakingGetter: auctionTail,
+                        customPostInteraction: exclusivityTail,
+                    }),
+                    preInteraction: delegatedMakerAddress,
+                },
+            );
+
+            await delegatedMaker.connect(user).createOrder(order, order.extension);
+            const announcedAt = Number(await registrator.announcedAt(await swap.hashOrder(order)));
+
+            // The exclusivity chained behind the fee taker still bites.
+            await time.setNextBlockTimestamp(announcedAt + 20);
+            await expect(fill(swap, order, MAKING_AMOUNT)).to.be.revertedWithCustomError(auction, 'AllowedTimeViolation');
+
+            const fillTime = announcedAt + 60;
+            await time.setNextBlockTimestamp(fillTime);
+            const auctionPrice = takingAmountFor(order, { ...auctionParams, startTime: announcedAt }, fillTime, MAKING_AMOUNT, MAKING_AMOUNT);
+            const withFee = ceilDiv(auctionPrice * (100000n + resolverFee), 100000n);
+            const feeAmount = withFee - ceilDiv(withFee * 100000n, 100000n + resolverFee);
+
+            const fillTx = fill(swap, order, MAKING_AMOUNT);
+            await expect(fillTx).to.changeTokenBalances(dai, [user, taker, delegatedMaker], [-MAKING_AMOUNT, MAKING_AMOUNT, 0]);
+            await expect(fillTx).to.changeTokenBalances(
+                weth,
+                [taker, user, stranger, feeTaker, delegatedMaker],
+                [-withFee, withFee - feeAmount, feeAmount, 0, 0],
+            );
+        });
+
+        it('refuses a fee order unless its bytes route proceeds back to the creator', async function () {
+            const { dai, weth, delegatedMaker, feeTaker } = await loadFixture(deployContractsAndInit);
+            const delegatedMakerAddress = await delegatedMaker.getAddress();
+            const feeTakerAddress = await feeTaker.getAddress();
+
+            const buildFeeOrder = (receiver, postInteraction) => buildOrder(
+                {
+                    maker: delegatedMakerAddress,
+                    receiver,
+                    makerAsset: dai.target,
+                    takerAsset: weth.target,
+                    makingAmount: MAKING_AMOUNT,
+                    takingAmount: TAKING_AMOUNT,
+                },
+                { preInteraction: delegatedMakerAddress, postInteraction },
+            );
+            const feeData = ({ flags = '0x01', customReceiver = user.address } = {}) => ethers.solidityPacked(
+                ['address', 'bytes1', 'address', 'address'].concat(customReceiver ? ['address'] : []),
+                [feeTakerAddress, flags, ethers.ZeroAddress, ethers.ZeroAddress].concat(customReceiver ? [customReceiver] : []),
+            );
+
+            // The custom-receiver flag is what makes a conforming fee taker forward the net at all.
+            const noFlag = buildFeeOrder(feeTakerAddress, feeData({ flags: '0x00' }));
+            await expect(delegatedMaker.connect(user).createOrder(noFlag, noFlag.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidFeeReceiver');
+
+            // A custom receiver naming anyone but the creator diverts the proceeds.
+            const wrongReceiver = buildFeeOrder(feeTakerAddress, feeData({ customReceiver: user2.address }));
+            await expect(delegatedMaker.connect(user).createOrder(wrongReceiver, wrongReceiver.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidFeeReceiver');
+
+            // The receiver must be the very contract whose post-interaction distributes, or the taking
+            // asset lands on an address that never forwards it.
+            const foreignTarget = buildFeeOrder(user2.address, feeData());
+            await expect(delegatedMaker.connect(user).createOrder(foreignTarget, foreignTarget.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidFeeReceiver');
+
+            // Too short to even carry a custom receiver.
+            const short = buildFeeOrder(feeTakerAddress, feeData({ customReceiver: false }));
+            await expect(delegatedMaker.connect(user).createOrder(short, short.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidFeeReceiver');
+
+            // Well-formed bytes with the post-interaction trait switched off never run the distribution.
+            const noHook = buildFeeOrder(feeTakerAddress, feeData());
+            noHook.makerTraits = BigInt(noHook.makerTraits) & ~(1n << 251n);
+            await expect(delegatedMaker.connect(user).createOrder(noHook, noHook.extension))
+                .to.be.revertedWithCustomError(delegatedMaker, 'InvalidFeeReceiver');
+
+            // The same well-formed shape, untampered, is accepted.
+            const valid = buildFeeOrder(feeTakerAddress, feeData());
+            await expect(delegatedMaker.connect(user).createOrder(valid, valid.extension))
+                .to.emit(delegatedMaker, 'DelegatedOrderCreated');
+        });
+    });
+
+    describe('permit', function () {
+        it('folds the allowance into the create transaction', async function () {
+            const { dai, weth, swap, chainId, registrator, delegatedMaker } = await loadFixture(deployContractsAndInit);
+            const delegatedMakerAddress = await delegatedMaker.getAddress();
+
+            // The maker asset is the permit-capable WETH; the user holds funds but has approved nothing.
+            await weth.connect(user).deposit({ value: ether('1') });
+
+            const order = buildOrder(
+                {
+                    maker: delegatedMakerAddress,
+                    receiver: user.address,
+                    makerAsset: await weth.getAddress(),
+                    takerAsset: await dai.getAddress(),
+                    makingAmount: ether('1'),
+                    takingAmount: ether('100'),
+                },
+                { preInteraction: delegatedMakerAddress },
+            );
+            const orderHash = await swap.hashOrder(order);
+
+            const permit = await getPermit(user.address, user, weth, '1', chainId, delegatedMakerAddress, ether('1').toString());
+            await delegatedMaker.connect(user).createOrderWithPermit(order, order.extension, permit);
+
+            // One transaction did everything: allowance, presign, broadcast and anchor.
+            expect(await weth.allowance(user, delegatedMaker)).to.equal(ether('1'));
+            expect(await registrator.announcedAt(orderHash)).to.equal(await time.latest());
+
+            const fillTx = fill(swap, order, ether('1'));
+            await expect(fillTx).to.changeTokenBalances(weth, [user, taker, delegatedMaker], [-ether('1'), ether('1'), 0]);
+            await expect(fillTx).to.changeTokenBalances(dai, [taker, user], [-ether('100'), ether('100')]);
+        });
+
+        it('shrugs off a front-run permit', async function () {
+            const { dai, weth, swap, chainId, delegatedMaker } = await loadFixture(deployContractsAndInit);
+            const delegatedMakerAddress = await delegatedMaker.getAddress();
+
+            await weth.connect(user).deposit({ value: ether('1') });
+
+            const order = buildOrder(
+                {
+                    maker: delegatedMakerAddress,
+                    receiver: user.address,
+                    makerAsset: await weth.getAddress(),
+                    takerAsset: await dai.getAddress(),
+                    makingAmount: ether('1'),
+                    takingAmount: ether('100'),
+                },
+                { preInteraction: delegatedMakerAddress },
+            );
+            const orderHash = await swap.hashOrder(order);
+
+            // Anyone can lift the permit from the mempool and submit it first; the allowance lands anyway.
+            const permit = await getPermit(user.address, user, weth, '1', chainId, delegatedMakerAddress, ether('1').toString());
+            const selector = weth.interface.getFunction('permit(address,address,uint256,uint256,uint8,bytes32,bytes32)').selector;
+            await stranger.sendTransaction({ to: await weth.getAddress(), data: selector + trim0x(permit) });
+            expect(await weth.allowance(user, delegatedMaker)).to.equal(ether('1'));
+
+            // The spent permit reverts inside the token and is swallowed; the order is created anyway
+            // and fills through the allowance the front-run itself granted.
+            await delegatedMaker.connect(user).createOrderWithPermit(order, order.extension, permit);
+            expect(await delegatedMaker.approvedOrders(orderHash)).to.equal(user.address);
+            await expect(fill(swap, order, ether('1')))
+                .to.changeTokenBalances(weth, [user, taker], [-ether('1'), ether('1')]);
+        });
+    });
+});

--- a/test/FusionAnchoredAuctionFork.js
+++ b/test/FusionAnchoredAuctionFork.js
@@ -53,7 +53,7 @@ const TAKING_AMOUNT = ether('0.03');
 describe('FusionAnchoredAuction (mainnet fork)', function () {
     this.timeout(600000);
 
-    let maker, taker;
+    let maker, taker, protocolRecipient;
     let router, dai, weth, registrator, auction;
     let chainId;
 
@@ -73,7 +73,7 @@ describe('FusionAnchoredAuction (mainnet fork)', function () {
         // Fail loudly if the reset silently produced a pristine chain instead of a fork.
         expect(await ethers.provider.getBlockNumber()).to.be.greaterThan(20_000_000);
 
-        [maker, taker] = await ethers.getSigners();
+        [maker, taker, protocolRecipient] = await ethers.getSigners();
         chainId = (await ethers.provider.getNetwork()).chainId;
         router = await ethers.getContractAt('LimitOrderProtocol', MAINNET.router);
         dai = await ethers.getContractAt('TokenMock', MAINNET.dai);
@@ -310,5 +310,133 @@ describe('FusionAnchoredAuction (mainnet fork)', function () {
         );
         await expect(fillTx).to.changeTokenBalances(dai, [taker, safe], [MAKING_AMOUNT, -MAKING_AMOUNT]);
         await expect(fillTx).to.changeTokenBalances(weth, [taker, safe], [-expected, expected]);
+    });
+
+    it('runs the DelegatedMaker flow end to end through the live router', async function () {
+        // The EOA flow with nothing signed and nothing escrowed: one createOrder transaction presigns and
+        // announces, the maker asset stays in the wallet until the live router's fill pulls it just in time.
+        const DelegatedMaker = await ethers.getContractFactory('DelegatedMaker');
+        const delegatedMaker = await DelegatedMaker.deploy(router, registrator);
+        await delegatedMaker.waitForDeployment();
+
+        await dai.connect(maker).approve(delegatedMaker, MAKING_AMOUNT);
+
+        const params = { startTime: 0, duration: 100, initialRateBump: Number(HALF_PERCENT), anchored: true };
+        const auctionData = ethers.solidityPacked(
+            ['address', 'bytes'],
+            [await auction.getAddress(), buildAnchoredAuctionDetails(params)],
+        );
+        const delegatedMakerAddress = await delegatedMaker.getAddress();
+        const order = buildOrder(
+            {
+                maker: delegatedMakerAddress,
+                receiver: maker.address,
+                makerAsset: MAINNET.dai,
+                takerAsset: MAINNET.weth,
+                makingAmount: MAKING_AMOUNT,
+                takingAmount: TAKING_AMOUNT,
+            },
+            { makingAmountData: auctionData, takingAmountData: auctionData, preInteraction: delegatedMakerAddress },
+        );
+        const orderHash = await router.hashOrder(order);
+
+        await delegatedMaker.connect(maker).createOrder(order, order.extension);
+        const announcedAt = await time.latest();
+        expect(await registrator.announcedAt(orderHash)).to.equal(announcedAt);
+
+        const fillTime = announcedAt + 60;
+        await time.setNextBlockTimestamp(fillTime);
+        const takerTraits = buildTakerTraits({ makingAmount: true, extension: order.extension });
+        const fillTx = router.connect(taker).fillContractOrderArgs(order, '0x', MAKING_AMOUNT, takerTraits.traits, takerTraits.args);
+
+        const expected = takingAmountFor(order, { ...params, startTime: announcedAt }, fillTime, MAKING_AMOUNT, MAKING_AMOUNT);
+        await expect(fillTx).to.changeTokenBalances(dai, [maker, taker, delegatedMaker], [-MAKING_AMOUNT, MAKING_AMOUNT, 0n]);
+        await expect(fillTx).to.changeTokenBalances(weth, [taker, maker], [-expected, expected]);
+    });
+
+    it('collects the live settlement surplus fee on a DelegatedMaker fill premium', async function () {
+        // The fee-collecting production shape end to end: the live Settlement is the order's receiver
+        // and pays the creator as its custom receiver. The surplus fee is set on purpose — the ladder
+        // premium lands above the quoted estimate, so the settlement taxes surplusFee% of it, pinning
+        // the number behind the rollout note that partial-fill premiums count as settlement surplus.
+        const DelegatedMaker = await ethers.getContractFactory('DelegatedMaker');
+        const delegatedMaker = await DelegatedMaker.deploy(router, registrator);
+        await delegatedMaker.waitForDeployment();
+        const delegatedMakerAddress = await delegatedMaker.getAddress();
+
+        await dai.connect(maker).approve(delegatedMaker, MAKING_AMOUNT);
+
+        const params = {
+            startTime: 0,
+            duration: 100,
+            initialRateBump: Number(HALF_PERCENT),
+            anchored: true,
+            fillPremiums: { initial: Number(HALF_PERCENT), points: [] },
+        };
+        const auctionTail = ethers.solidityPacked(
+            ['address', 'bytes'],
+            [await auction.getAddress(), buildAnchoredAuctionDetails(params)],
+        );
+        const getterData = ethers.solidityPacked(
+            ['address', 'bytes', 'bytes', 'bytes'],
+            [MAINNET.settlement, buildLegacyAuctionDetails(), NO_FEE_DATA, auctionTail],
+        );
+        const surplusFee = 50n; // in 1e2: half of anything above the estimate goes to the protocol
+        const postInteractionData = ethers.solidityPacked(
+            ['address', 'bytes1', 'address', 'address', 'address', 'uint16', 'uint8', 'uint16', 'uint8', 'uint32', 'uint8', 'uint80', 'uint16', 'uint256', 'uint8'],
+            [
+                MAINNET.settlement,
+                '0x01', // custom receiver follows the fee recipients
+                constants.ZERO_ADDRESS, // integrator fee recipient
+                protocolRecipient.address,
+                maker.address, // custom receiver: the creator, enforced by DelegatedMaker
+                0, 0, 0, 0, // no integrator fee, share, resolver fee or whitelist discount
+                0, 1, BigInt(taker.address) & ((1n << 80n) - 1n), 0, // whitelist open from time zero
+                TAKING_AMOUNT, surplusFee, // the quoted estimate and the surplus cut
+            ],
+        );
+        const order = buildOrder(
+            {
+                maker: delegatedMakerAddress,
+                receiver: MAINNET.settlement,
+                makerAsset: MAINNET.dai,
+                takerAsset: MAINNET.weth,
+                makingAmount: MAKING_AMOUNT,
+                takingAmount: TAKING_AMOUNT,
+            },
+            {
+                makingAmountData: getterData,
+                takingAmountData: getterData,
+                preInteraction: delegatedMakerAddress,
+                postInteraction: postInteractionData,
+            },
+        );
+
+        await delegatedMaker.connect(maker).createOrder(order, order.extension);
+        const announcedAt = await time.latest();
+
+        // Half the order after the auction: the price is the plain rate plus the ladder premium.
+        const fillTime = announcedAt + 200;
+        await time.setNextBlockTimestamp(fillTime);
+        const fillAmount = MAKING_AMOUNT / 2n;
+        const actualTaking = takingAmountFor(order, { ...params, startTime: announcedAt }, fillTime, fillAmount, MAKING_AMOUNT);
+
+        // The settlement compares against the estimate scaled to the fill, so the whole premium counts
+        // as surplus here and half of it is taxed.
+        const scaledEstimate = (TAKING_AMOUNT * fillAmount + MAKING_AMOUNT - 1n) / MAKING_AMOUNT;
+        const surplusCut = (actualTaking - scaledEstimate) * surplusFee / 100n;
+        expect(surplusCut).to.be.greaterThan(0n);
+
+        const takerTraits = buildTakerTraits({ makingAmount: true, extension: order.extension });
+        const fillTx = router.connect(taker).fillContractOrderArgs(
+            order, '0x', fillAmount, takerTraits.traits, takerTraits.args, { maxPriorityFeePerGas: 0 },
+        );
+
+        await expect(fillTx).to.changeTokenBalances(dai, [maker, taker, delegatedMaker], [-fillAmount, fillAmount, 0n]);
+        await expect(fillTx).to.changeTokenBalances(
+            weth,
+            [taker, maker, protocolRecipient],
+            [-actualTaking, actualTaking - surplusCut, surplusCut],
+        );
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #430 — the announcement-anchored auction and the maker-only, signature-free `OrderRegistrator` this contract builds on. The base branch is `cursor/fusion-announcement-anchored-auction-9252`; GitHub retargets this PR to `master` when #430 merges, and since the repo merges with merge commits the diff collapses to the `DelegatedMaker` changes with no rebase.

Split out of #430 deliberately: this is the one custody-adjacent surface of the feature set. A contract that concentrates standing allowances reviews differently from pure pricing logic, so the auction core and this helper each get a review pass matched to their risk. Nothing in #430 references this contract; it composes from the outside like any other maker.

## What it is

**`DelegatedMaker`** gives ERC-20 makers the flow the feature set was built toward — **one transaction per order, no signature, no escrow**. One shared contract is the maker for all of its users (CoW Protocol's presign plus its VaultRelayer just-in-time pull, as prior art): `createOrder` records the caller as the order's owner (the presign read by `isValidSignature`), validates that the order names this contract as maker, the remaining invalidator (the bit-invalidator nonce space would be shared across users) and a pre-interaction routed to this contract, then announces — anchoring the auction clock at the create block. Funds stay in the owner's wallet until the fill: the pre-interaction pulls exactly the filled amount through the owner's standing allowance immediately before the maker-asset transfer, topping up the protocol's own allowance for the maker asset whenever it runs short (this lazy top-up replaced a one-shot `approveRouter` step during #430's pruning rounds, fixing the latent depletion defect for tokens that decrement even infinite allowances), so custody time is zero and the contract holds no balances between transactions. `createOrderWithPermit` folds the owner's EIP-2612 allowance into the create transaction itself — owner pinned to the caller, failures swallowed the way the protocol treats maker permits, so a front-run permit changes nothing and a wrong one leaves an order that a later approval revives. `cancelOrder` deletes the presign **and** invalidates at the protocol as the maker — both load-bearing, since the core validates ERC-1271 only on the first fill (`OrderMixin._fillContractOrder`) — and the duplicate check reads the registrator's ever-registered state, so a cancelled order cannot be re-created into a presigned-but-protocol-dead shell. The contract concentrates standing allowances (the same trust shape as the router itself) and has no owner powers over user funds.

**Proceeds must route to the creator, one way or the other.** The default rule is `receiver == creator`. A non-creator receiver is accepted in exactly one shape — fee collection: the order's post-interaction must target the receiver itself (which is `FeeTaker`'s own distribution condition, `order.receiver.get() == address(this)`), carry the custom-receiver flag, and name the creator in the custom-receiver slot, with the post-interaction maker trait set. That guarantees a conforming `FeeTaker`-layout settlement forwards the net to the wallet that funded the order; anything else — a zero receiver, missing hook trait, short fee bytes, a foreign target or a foreign custom receiver — reverts `InvalidFeeReceiver`, because each of those strands or diverts the taking asset (`FeeTaker` would otherwise pay the maker's share to `order.maker`, the shared contract, which deliberately cannot withdraw). The fee contract itself is the creator's choice and trust; naming a hostile one harms only the creator, whose funds alone back the order.

## How it fits among the flows

![Flow diagram: three creation flows (DelegatedMaker, a Safe MultiSend batch, classic EOA) all reaching the registrator as the maker of the order, and the fill path showing the presign check, the just-in-time pull and the post-interaction](https://cursor.com/artifacts/c/art-eeab6b3d-69cc-4abd-a5a0-abb7ca1235fc)

The Safe and classic-EOA lanes ship in #430; this PR adds the top lane and the just-in-time pull row.

## Open product decision: the fee shape

The fee-collection validation is the most coupling-heavy part of this contract — it mirrors `FeeTaker`'s custom-receiver byte layout (`_CUSTOM_RECEIVER_OFFSET = 61`), the only place in the stack that depends on another contract's internals. It is kept because production Fusion orders route fees through the settlement-as-receiver, which is exactly this shape. If a feeless v1 for delegated orders is acceptable (the quoter zeroes integrator and protocol fees for them), the whole validation collapses to the one-line `receiver == creator` rule and the coupling disappears; re-adding it later is purely additive. Flagging the choice here rather than deciding it.

## Tests

18 unit tests against `LimitOrderProtocol`, restored byte-identical from #430's pre-split state: the one-transaction lifecycle (create → anchored at the create block → filled with the empty signature, wallet untouched until the fill, the shared contract holding nothing before or after, and the protocol allowance self-provisioned on the first fill); exact just-in-time pulls across partial fills with proceeds landing on the owner directly; every creation rule rejected (wrong maker, zero receiver, bit-invalidator traits, missing pre-interaction hook, foreign pre-interaction target, duplicate hash, cancel-then-recreate); **fee collection in the full production shape** — fee taker as receiver paying the creator as custom receiver, anchored auction through the fee taker's getters, exclusivity through its post-interaction tail, the pull on the same order — plus five fee-shape reverts (missing flag, foreign custom receiver, foreign target, short bytes, missing hook trait) with a positive control; **both permit paths** — the allowance folded into one create transaction, and a front-run permit swallowed with the order still created and fillable; cancellation of a half-filled order killing the rest at the protocol (the first-fill-only ERC-1271 nuance); pull authorization (non-protocol callers and ownerless orders both refused); and two users on the shared maker isolated from each other's orders and cancellations.

2 mainnet-fork integration tests (the fourth and fifth of the stack's five, `yarn test:fork` with `MAINNET_RPC_URL` set):

- the **`DelegatedMaker` flow end to end through the live Aggregation Router V6**: allowance, one `createOrder` transaction, and a fill that pulls just in time — nothing signed, nothing escrowed, the protocol allowance self-provisioned inside the fill;
- **fee collection through the live Fusion settlement** (`0x2Ad5004c60e16E54d5007C80CE329Adde5B51Ef5`): the settlement is the order's receiver and pays the creator as its custom receiver, with a deliberate surplus fee set — the fill's curve premium lands above the scaled estimate and the settlement takes exactly `surplusFee%` of it, pinning the surplus-on-premium interaction #430's composition notes reference.

On this branch the full stack holds **100% coverage across statements, branches, functions and lines on all three contracts** (`DelegatedMaker`, plus #430's `FusionAnchoredAuction` and `OrderRegistrator`); 239 unit tests and all 5 fork tests pass.

## Review trail

The contract went through #430's seven Bugbot rounds while it lived there — including the round dedicated to the maker-only authorization and the round dedicated to the fee shape and permit paths — plus an eighth round on this split, focused on the restore commit and the stack's consistency (registrator two-argument `registerOrder`, the `announcedAt` duplicate check, the pull path, the fee offsets, permit owner-pinning, the dual-action cancel): no findings. The Slither run and the audit cross-checks recorded in #430's trail covered this contract as well.

## Follow-ups

- Fees couple to `FeeTaker`'s custom-receiver layout by design; if the layout ever moves, the offsets in `_createOrder` move with it.
- EIP-7702 is the eventual per-user alternative to the shared maker: a delegated EOA can hold the presign locally with no allowance concentration and the same one-transaction UX, and needs nothing from this repo.
- Deploys through its own create3 salt and deploy script, after the registrator and the auction.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68f8e998-b576-4b42-ae5b-10ea38259252?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68f8e998-b576-4b42-ae5b-10ea38259252&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

