### PR TITLE
test: make yarn test pass under --parallel

### DIFF
--- a/test/LimitOrderProtocol.js
+++ b/test/LimitOrderProtocol.js
@@ -3,7 +3,7 @@ const { ethers, network, tracer } = hre;
 const { expect, time, constants, getPermit2, permit2Contract } = require('@1inch/solidity-utils');
 const { ABIOrder, fillWithMakingAmount, unwrapWethTaker, buildMakerTraits, buildMakerTraitsRFQ, buildOrder, signOrder, buildOrderData, buildTakerTraits } = require('./helpers/orderUtils');
 const { getPermit, withTarget } = require('./helpers/eip712');
-const { joinStaticCalls, ether, findTrace, countAllItems, withTrace, getEventArgs } = require('./helpers/utils');
+const { joinStaticCalls, ether, findTrace, countAllItems, withTrace, getEventArgs, tracingAvailable } = require('./helpers/utils');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { deploySwapTokens, deployArbitraryPredicate } = require('./helpers/fixtures');
 const { parseUnits } = require('ethers');
@@ -259,7 +259,7 @@ describe('LimitOrderProtocol', function () {
                 await expect(fillTx).to.changeTokenBalances(dai, [addr, addr1], [1, -1]);
                 await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1], [-1, 1]);
 
-                if (hre.__SOLIDITY_COVERAGE_RUNNING === undefined) {
+                if (hre.__SOLIDITY_COVERAGE_RUNNING === undefined && tracingAvailable()) {
                     const trace = findTrace(tracer, 'CALL', await swap.getAddress());
                     const opcodes = trace.children.map(item => item.opcode);
                     expect(countAllItems(opcodes)).to.deep.equal({ STATICCALL: 1, CALL: 2, SLOAD: 2, SSTORE: 1, LOG1: 1, MSTORE: 29, MLOAD: 10, RETURN: 1 });
@@ -286,7 +286,7 @@ describe('LimitOrderProtocol', function () {
             await expect(fillTx).to.changeTokenBalances(dai, [addr, addr1], [1, -1]);
             await expect(fillTx).to.changeTokenBalances(weth, [addr, addr1], [-1, 1]);
 
-            if (hre.__SOLIDITY_COVERAGE_RUNNING === undefined) {
+            if (hre.__SOLIDITY_COVERAGE_RUNNING === undefined && tracingAvailable()) {
                 const trace = findTrace(tracer, 'CALL', await swap.getAddress());
                 const opcodes = trace.children.map(item => item.opcode);
                 expect(countAllItems(opcodes)).to.deep.equal({ STATICCALL: 1, CALL: 2, SLOAD: 2, SSTORE: 1, LOG1: 1, MSTORE: 31, MLOAD: 10, RETURN: 1 });

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -39,6 +39,10 @@ async function withTrace (tracer, fn, level = 1) {
     }
 }
 
+// hardhat-tracer's recorder lives in the main process, so under mocha's parallel workers
+// (`hardhat test --parallel`) it collects nothing and findTrace has no trace to return.
+const tracingAvailable = () => process.env.MOCHA_WORKER_ID === undefined;
+
 // findTrace(tracer, 'CALL', exchange.address)
 function findTrace (tracer, opcode, address) {
     return tracer.allTraces().filter(
@@ -131,6 +135,7 @@ module.exports = {
     calculateGasUsed,
     withTrace,
     findTrace,
+    tracingAvailable,
     flattenTree,
     countAllItems,
     treeForEach,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two independent fixes, both off `master`. This PR previously stacked on #433; that PR is closed and its one-line fix is folded in here (it also lives in #430 — identical change, verified to merge cleanly in either order).

## 1. `yarn test` fails under `--parallel`

`yarn test` is `hardhat test --parallel`, and it fails on master with two errors:

```
  171 passing (3s)
  5 pending
  2 failing

  1) LimitOrderProtocol > wip > should swap fully based on signature:
     TypeError: Cannot read properties of undefined (reading 'top')
      at findTrace (test/helpers/utils.js:46:19)

  2) LimitOrderProtocol > wip > should swap half based on signature:
```

CI stays green because it runs `yarn test:ci`, which is `hardhat test` without `--parallel`. So the breakage is invisible to CI and hits every contributor who runs the documented test command.

**Root cause.** Both tests assert exact opcode counts through hardhat-tracer. Its recorder lives in the main process, so under mocha's parallel workers it collects nothing: `tracer.allTraces()` returns `[]`, the filter in `findTrace` matches nothing, and `.slice(-1)[0].top` dereferences `undefined`.

Upgrading the tracer does not help. I tried `hardhat-tracer@3.4.0` against the pinned 3.2.1 and reproduced the identical two failures, so that dependency bump is not included here.

**The fix.** These assertions already carry a guard for exactly this shape of problem — they are skipped under coverage, because instrumentation rewrites the opcodes being counted. This extends that existing guard rather than inventing a new mechanism:

```js
// hardhat-tracer's recorder lives in the main process, so under mocha's parallel workers
// (`hardhat test --parallel`) it collects nothing and findTrace has no trace to return.
const tracingAvailable = () => process.env.MOCHA_WORKER_ID === undefined;
```

`MOCHA_WORKER_ID` was chosen after probing both modes rather than reading it off a docs page: it is set to a worker index under `--parallel` and absent in serial runs. The comparison is `=== undefined` rather than a truthiness check, since worker zero reports the string `"0"`.

Splitting the two tests into their own serial file was considered and rejected: they sit inside a `describe` block that shares an 85-line `deployContractsAndInit` fixture and a `before` hook establishing four signers, so extracting them would mean duplicating all of it. Dropping `--parallel` was also rejected on measurement — warm runs are about 5.0s parallel against 7.3s serial, so it is worth keeping.

Under `--parallel` the two tests still execute the fill and assert the DAI and WETH balance changes; only the opcode-count assertion is skipped. That is a deliberate trade: opcode regressions are caught by CI's serial run rather than locally, matching how the existing coverage guard already behaves.

## 2. `getNamedAccounts` in the Permit2Proxy deploy script

`deploy/deploy-Permit2Proxy.js` calls `getNamedAccounts()` but never destructures it from the hardhat-deploy arguments, so the script throws at runtime and ESLint flags `no-undef`. Because `lint:js` and `lint:sol` run under one `yarn lint`, that single error has kept **master's lint job red**, which is also why this PR needs the fix to have green CI of its own. The corrected signature matches every other script in `deploy/`:

```js
module.exports = async ({ deployments, getNamedAccounts }) => {
```

I scanned the other seven scripts in `deploy/` for the same mismatch — calling `getNamedAccounts()` without destructuring it — and this was the only one.

## Verification

| Run | Before | After |
| --- | --- | --- |
| `yarn test` (parallel) | 171 passing, **2 failing** | **173 passing**, 0 failing |
| `yarn test:ci` (serial, CI) | 173 passing | 173 passing |
| `yarn coverage` | 160 passing | 160 passing |
| `yarn lint` | **1 error** | clean |

The opcode assertions are skipped, not silently defeated. I proved the regression guard still fires where it can run by temporarily corrupting an expected count to `MSTORE: 999`:

- `yarn test:ci` (serial): **1 failing**, reporting the bad `MSTORE: 999` count — CI still catches opcode regressions.
- `yarn test` (parallel): 173 passing — correctly skipped, as intended.

The corrupted expectation was reverted; the diff carries only the guard.

I also merged this branch together with #430 and #432 onto master in a scratch branch to check the combination that no CI job builds: all four merge cleanly in any order, and the integrated tree gives 252 passing / 0 failing in both parallel and serial, 100% coverage on the three contracts those PRs ship, and 5 passing fork tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68f8e998-b576-4b42-ae5b-10ea38259252?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68f8e998-b576-4b42-ae5b-10ea38259252&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

