### PR TITLE
feat: record first announcement time in OrderRegistrator

### DIFF
--- a/contracts/helpers/OrderRegistrator.sol
+++ b/contracts/helpers/OrderRegistrator.sol
@@ -48,7 +48,6 @@ contract OrderRegistrator is IOrderRegistrator {
         if(!ECDSA.recoverOrIsValidSignature(order.maker.get(), orderHash, signature)) revert IOrderMixin.BadSignature();
 
         if (announcedAt[orderHash] == 0) {
-            // solhint-disable-next-line not-rely-on-time
             announcedAt[orderHash] = block.timestamp;
         }
 

--- a/contracts/helpers/OrderRegistrator.sol
+++ b/contracts/helpers/OrderRegistrator.sol
@@ -17,6 +17,11 @@ contract OrderRegistrator is IOrderRegistrator {
 
     IOrderMixin private immutable _LIMIT_ORDER_PROTOCOL;
 
+    /**
+     * @notice See {IOrderRegistrator-announcedAt}.
+     */
+    mapping(bytes32 orderHash => uint256 timestamp) public announcedAt;
+
     constructor(IOrderMixin limitOrderProtocol) {
         _LIMIT_ORDER_PROTOCOL = limitOrderProtocol;
     }
@@ -37,8 +42,15 @@ contract OrderRegistrator is IOrderRegistrator {
             }
         }
 
+        bytes32 orderHash = _LIMIT_ORDER_PROTOCOL.hashOrder(order);
+
         // Validate signature
-        if(!ECDSA.recoverOrIsValidSignature(order.maker.get(), _LIMIT_ORDER_PROTOCOL.hashOrder(order), signature)) revert IOrderMixin.BadSignature();
+        if(!ECDSA.recoverOrIsValidSignature(order.maker.get(), orderHash, signature)) revert IOrderMixin.BadSignature();
+
+        if (announcedAt[orderHash] == 0) {
+            // solhint-disable-next-line not-rely-on-time
+            announcedAt[orderHash] = block.timestamp;
+        }
 
         emit OrderRegistered(order, extension, signature);
     }

--- a/contracts/interfaces/IOrderRegistrator.sol
+++ b/contracts/interfaces/IOrderRegistrator.sol
@@ -25,4 +25,11 @@ interface IOrderRegistrator {
      * @param signature The signature of the order.
      */
     function registerOrder(IOrderMixin.Order calldata order, bytes calldata extension, bytes calldata signature) external;
+
+    /**
+     * @notice Returns the time an order was first registered, or zero when it never was.
+     * @param orderHash The hash of the order.
+     * @return timestamp The block timestamp of the first registration.
+     */
+    function announcedAt(bytes32 orderHash) external view returns (uint256 timestamp);
 }

--- a/deploy/deploy-Permit2Proxy.js
+++ b/deploy/deploy-Permit2Proxy.js
@@ -5,7 +5,7 @@ const { ethers, getChainId } = hre;
 const { permit2Address } = require('@uniswap/permit2-sdk');
 const constants = require('../config/constants');
 
-module.exports = async ({ deployments }) => {
+module.exports = async ({ deployments, getNamedAccounts }) => {
     const networkName = hre.network.name;
     console.log(`running ${networkName} deploy script`);
     const chainId = await getChainId();

--- a/deploy/deploy-helpers.js
+++ b/deploy/deploy-helpers.js
@@ -53,6 +53,12 @@ module.exports = async ({ getNamedAccounts, deployments, config }) => {
         let result;
 
         if (DEPLOYMENT_METHOD === 'create3') {
+            if (helperName === 'OrderRegistrator' && !helperConfig.salt) {
+                // The default salt resolves to the address the previous, announcement-less registrator already
+                // occupies on every chain it was deployed to.
+                throw new Error('Deploying OrderRegistrator requires an explicit salt, as the default one is already taken by the deployment that predates stored announcements.');
+            }
+
             const salt = helperConfig.salt
                 ? (
                     helperConfig.salt.startsWith('0x')

--- a/docs/interfaces/IOrderRegistrator.md
+++ b/docs/interfaces/IOrderRegistrator.md
@@ -6,6 +6,7 @@ The registrator is responsible for registering orders and emitting an event when
 
 ### Functions list
 - [registerOrder(order, extension, signature) external](#registerorder)
+- [announcedAt(orderHash) external](#announcedat)
 
 ### Events list
 - [OrderRegistered(order, extension, signature) ](#orderregistered)
@@ -25,6 +26,25 @@ Registers an order.
 | order | struct IOrderMixin.Order | The order to be registered. |
 | extension | bytes | The extension data associated with the order. |
 | signature | bytes | The signature of the order. |
+
+### announcedAt
+
+```solidity
+function announcedAt(bytes32 orderHash) external view returns (uint256 timestamp)
+```
+Returns the time an order was first registered, or zero when it never was.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| orderHash | bytes32 | The hash of the order. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+timestamp | uint256 | The block timestamp of the first registration. |
 
 ### Events
 ### OrderRegistered

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -45,6 +45,8 @@ module.exports = {
             '@1inch/solidity-utils/contracts/mocks/TokenCustomDecimalsMock.sol',
             '@1inch/solidity-utils/contracts/mocks/TokenMock.sol',
             '@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol',
+            '@gnosis.pm/safe-contracts/contracts/libraries/MultiSend.sol',
+            '@gnosis.pm/safe-contracts/contracts/examples/libraries/SignMessage.sol',
         ],
     },
     docgen: {

--- a/test/OrderRegistrator.js
+++ b/test/OrderRegistrator.js
@@ -1,14 +1,20 @@
-const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
-const { expect } = require('@1inch/solidity-utils');
+const { loadFixture, time } = require('@nomicfoundation/hardhat-network-helpers');
+const { expect, constants, ether } = require('@1inch/solidity-utils');
 const { signOrder, buildOrder } = require('./helpers/orderUtils');
 const { ethers } = require('hardhat');
 const { deploySwap, deployUSDC, deployUSDT } = require('./helpers/fixtures');
+const { executeContractCallWithSigners } = require('@gnosis.pm/safe-contracts/dist');
+
+/** Packs one transaction of a MultiSend batch: operation, target, value, data length, data. */
+function encodeMultiSendTx (operation, to, data) {
+    return ethers.solidityPacked(['uint8', 'address', 'uint256', 'uint256', 'bytes'], [operation, to, 0, ethers.dataLength(data), data]);
+}
 
 describe('OrderRegistrator', function () {
-    let addr;
+    let addr, addr1;
 
     before(async function () {
-        [addr] = await ethers.getSigners();
+        [addr, addr1] = await ethers.getSigners();
     });
 
     async function deployAndInit () {
@@ -72,5 +78,146 @@ describe('OrderRegistrator', function () {
         const signature = ethers.Signature.from(await signOrder(order, chainId, await swap.getAddress(), addr)).compactSerialized;
         const tx = registrator.registerOrder(order, order.extension + '00', signature);
         await expect(tx).to.be.revertedWithCustomError(orderLibFactory, 'UnexpectedOrderExtension');
+    });
+
+    describe('announcements', function () {
+        async function buildSignedOrder (usdc, usdt, swap, chainId) {
+            const order = buildOrder({
+                makerAsset: await usdc.getAddress(),
+                takerAsset: await usdt.getAddress(),
+                makingAmount: 1,
+                takingAmount: 2,
+                maker: addr.address,
+            });
+            const signature = ethers.Signature.from(await signOrder(order, chainId, await swap.getAddress(), addr)).compactSerialized;
+            return { order, signature };
+        }
+
+        it('should record the time of the first registration', async function () {
+            const { usdc, usdt, swap, registrator, chainId } = await loadFixture(deployAndInit);
+            const { order, signature } = await buildSignedOrder(usdc, usdt, swap, chainId);
+            const orderHash = await swap.hashOrder(order);
+
+            expect(await registrator.announcedAt(orderHash)).to.equal(0);
+
+            await registrator.registerOrder(order, order.extension, signature);
+            expect(await registrator.announcedAt(orderHash)).to.equal(await time.latest());
+        });
+
+        it('should keep the first timestamp and still emit on a repeated registration', async function () {
+            const { usdc, usdt, swap, registrator, chainId } = await loadFixture(deployAndInit);
+            const { order, signature } = await buildSignedOrder(usdc, usdt, swap, chainId);
+            const orderHash = await swap.hashOrder(order);
+
+            await registrator.registerOrder(order, order.extension, signature);
+            const announcedAt = await registrator.announcedAt(orderHash);
+
+            await time.increase(3600);
+            const tx = registrator.registerOrder(order, order.extension, signature);
+            await expect(tx).to.emit(registrator, 'OrderRegistered');
+            expect(await registrator.announcedAt(orderHash)).to.equal(announcedAt);
+        });
+
+        it('should accept a registration relayed by anyone with a valid signature', async function () {
+            const { usdc, usdt, swap, registrator, chainId } = await loadFixture(deployAndInit);
+            const { order, signature } = await buildSignedOrder(usdc, usdt, swap, chainId);
+            const orderHash = await swap.hashOrder(order);
+
+            const tx = registrator.connect(addr1).registerOrder(order, order.extension, signature);
+            await expect(tx).to.emit(registrator, 'OrderRegistered');
+            expect(await registrator.announcedAt(orderHash)).to.equal(await time.latest());
+        });
+    });
+
+    describe('announcement by a contract maker', function () {
+        async function deploySafeAndInit () {
+            const { swap, usdc, usdt, registrator } = await deployAndInit();
+
+            const GnosisSafeProxyFactory = await ethers.getContractFactory('GnosisSafeProxyFactory');
+            const proxyFactoryContract = await GnosisSafeProxyFactory.deploy();
+            await proxyFactoryContract.waitForDeployment();
+            const GnosisSafe = await ethers.getContractFactory('GnosisSafe');
+            const gnosisSafeContract = await GnosisSafe.deploy();
+            await gnosisSafeContract.waitForDeployment();
+            const CompatibilityFallbackHandler = await ethers.getContractFactory('CompatibilityFallbackHandler');
+            const fallbackHandler = await CompatibilityFallbackHandler.deploy();
+            await fallbackHandler.waitForDeployment();
+            const AggregatorMock = await ethers.getContractFactory('AggregatorMock');
+            const oracle = await AggregatorMock.deploy(ether('0.00025'));
+            await oracle.waitForDeployment();
+            const SafeOrderBuilder = await ethers.getContractFactory('SafeOrderBuilder');
+            const safeOrderBuilder = await SafeOrderBuilder.deploy(swap, registrator);
+            await safeOrderBuilder.waitForDeployment();
+
+            const setupData = gnosisSafeContract.interface.encodeFunctionData(
+                'setup',
+                [[addr.address], 1, constants.ZERO_ADDRESS, '0x', await fallbackHandler.getAddress(), constants.ZERO_ADDRESS, 0, constants.ZERO_ADDRESS],
+            );
+            const receipt = await (await proxyFactoryContract.createProxy(await gnosisSafeContract.getAddress(), setupData)).wait();
+            const safe = GnosisSafe.attach(receipt.logs[1].args[0]);
+
+            // workaround as safe lib expects old version of ethers
+            safe.address = await safe.getAddress();
+            safeOrderBuilder.address = await safeOrderBuilder.getAddress();
+            addr._signTypedData = addr.signTypedData;
+
+            const order = buildOrder({
+                makerAsset: await usdc.getAddress(),
+                takerAsset: await usdt.getAddress(),
+                makingAmount: 100n,
+                takingAmount: 100n,
+                maker: await safe.getAddress(),
+            });
+
+            return { swap, registrator, safe, safeOrderBuilder, oracle, order };
+        }
+
+        it('should record an announcement made through SafeOrderBuilder', async function () {
+            const { swap, registrator, safe, safeOrderBuilder, oracle, order } = await loadFixture(deploySafeAndInit);
+
+            const oracleParams = [await oracle.getAddress(), ether('0.00025'), 1000];
+            const tx = await executeContractCallWithSigners(
+                safe,
+                safeOrderBuilder,
+                'buildAndSignOrder',
+                [order, order.extension, oracleParams, oracleParams],
+                [addr],
+                true,
+            );
+            await tx.wait();
+
+            const orderHash = await swap.hashOrder(order);
+            await expect(tx).to.emit(registrator, 'OrderRegistered');
+            expect(await registrator.announcedAt(orderHash)).to.equal(await time.latest());
+        });
+
+        it('should record an announcement made through a MultiSend batch with an empty signature', async function () {
+            const { swap, registrator, safe, order } = await loadFixture(deploySafeAndInit);
+
+            const MultiSend = await ethers.getContractFactory('MultiSend');
+            const multiSend = await MultiSend.deploy();
+            await multiSend.waitForDeployment();
+            const SignMessageLib = await ethers.getContractFactory('SignMessageLib');
+            const signMessageLib = await SignMessageLib.deploy();
+            await signMessageLib.waitForDeployment();
+
+            // workaround as safe lib expects old version of ethers
+            multiSend.address = await multiSend.getAddress();
+
+            // The batch marks the digest first, so the empty signature passes the ERC-1271 check.
+            const orderHash = await swap.hashOrder(order);
+            const batch = ethers.concat([
+                encodeMultiSendTx(1, await signMessageLib.getAddress(), signMessageLib.interface.encodeFunctionData('signMessage', [orderHash])),
+                encodeMultiSendTx(0, await registrator.getAddress(), registrator.interface.encodeFunctionData('registerOrder', [order, order.extension, '0x'])),
+            ]);
+            const tx = await executeContractCallWithSigners(safe, multiSend, 'multiSend', [batch], [addr], true);
+            await tx.wait();
+
+            await expect(tx).to.emit(registrator, 'OrderRegistered');
+            expect(await registrator.announcedAt(orderHash)).to.equal(await time.latest());
+
+            const validator = await ethers.getContractAt('CompatibilityFallbackHandler', safe.address);
+            expect(await validator['isValidSignature(bytes32,bytes)'](orderHash, '0x')).to.equal('0x1626ba7e');
+        });
     });
 });

--- a/test/OrderRegistrator.js
+++ b/test/OrderRegistrator.js
@@ -191,6 +191,13 @@ describe('OrderRegistrator', function () {
             expect(await registrator.announcedAt(orderHash)).to.equal(await time.latest());
         });
 
+        it('should reject an empty signature for a contract maker that has not presigned', async function () {
+            const { swap, registrator, order } = await loadFixture(deploySafeAndInit);
+
+            const tx = registrator.registerOrder(order, order.extension, '0x');
+            await expect(tx).to.be.revertedWithCustomError(swap, 'BadSignature');
+        });
+
         it('should record an announcement made through a MultiSend batch with an empty signature', async function () {
             const { swap, registrator, safe, order } = await loadFixture(deploySafeAndInit);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Extracted from #430 per review feedback (split by repo; Fusion-specific auction mechanics move to `fusion-protocol`). This PR is the only limit-order-protocol change the anchored auction needs.

## What

`OrderRegistrator.registerOrder` keeps its exact master semantics — permissionless, ECDSA/ERC-1271-validated, `OrderRegistered(order, extension, signature)` emitted on every call — and additionally records `announcedAt[orderHash] = block.timestamp` on the first registration. The timestamp is write-once: repeated registrations re-emit the event (re-broadcast, as today) but can never move the recorded time.

`IOrderRegistrator` gains one view:

```solidity
function announcedAt(bytes32 orderHash) external view returns (uint256 timestamp);
```

## Why

A Fusion auction starts at an absolute timestamp baked into the order at build time; a maker that signs slowly (a multisig collecting signatures) misses its own auction window and degrades to the floor price. The announcement-anchored auction extension — now open as [fusion-protocol#223](https://github.com/1inch/fusion-protocol/pull/223), inheriting the auction base extracted from `SimpleSettlement` — starts the schedule from `announcedAt` instead. This contract is the anchor's source of truth, and the write-once rule is what makes the anchor trustworthy: nobody can restart an auction by re-announcing.

## Notes

- No protocol changes; no redeploys. The updated registrator deploys at a new address; the existing one keeps serving legacy announcements. `deploy-helpers.js` now refuses to deploy `OrderRegistrator` without an explicit create3 salt, since the default salt resolves to the already-occupied address.
- `SafeOrderBuilder` is untouched and works as-is against the new registrator. One ops note: a `SafeOrderBuilder` instance wired to the *old* registrator keeps announcing fine but records no anchor, so an anchored-auction order announced that way fails closed at fill (`OrderNotAnnounced`) — Safe flows that want anchoring must go through the new registrator (a rewired `SafeOrderBuilder` or the MultiSend batch directly).
- New tests cover: first-write recording, write-once under re-registration, third-party relay of a signed announcement, the `SafeOrderBuilder` flow, a Safe announcing via one MultiSend batch (`SignMessageLib.signMessage` + `registerOrder` with an empty signature validated through ERC-1271 — the pattern `SafeOrderBuilder` already uses internally), and the negative gate: an empty signature for a contract maker that has **not** presigned reverts `BadSignature`.
- Carries the one-line `deploy-Permit2Proxy.js` lint fix (`getNamedAccounts` was not destructured), which `yarn lint` fails on at master; kept as a separate commit.

## Verification

`yarn lint` clean; full suite `yarn test:ci` green (179 passing); coverage on `OrderRegistrator.sol` is 100% statements/branches/functions/lines; docs regenerated for the touched interface only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68f8e998-b576-4b42-ae5b-10ea38259252?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68f8e998-b576-4b42-ae5b-10ea38259252&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

